### PR TITLE
ci(workflow): add step-security - harden runner & update actions version - v4 to v6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
# Description

## Primary

Add Step-Security harden runner to audit network operations and strengthen the security of GHA workflows. 

Read more: https://github.com/marketplace/actions/harden-runner

## Secondary

Update the GHA actions version from `v4` to `v6` _(latest)_.

# Task

- [x] Update GHA `lint.yml` workflow.
- [x] Update GHA actions version from `v4` to `v6`. 
- [x] Run workflow locally before creating PR. 

Ref: https://github.com/DAShaikh10/syncup/actions/runs/21564293257/job/62133188660
<img width="1210" height="790" alt="image" src="https://github.com/user-attachments/assets/2e2a6f87-0a4a-4331-8342-0e1f397bd3fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security with additional runtime hardening.
  * Updated build workflow dependencies to latest stable versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->