### PR TITLE
feat(projects): [#5] Implement project CRUD API endpoints

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.1",
+    "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.1",
-    "@nestjs/mapped-types": "*",
+    "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UsersModule } from '@/users/users.module';
 import { AuthModule } from '@/auth/auth.module';
+import { ProjectsModule } from './projects/projects.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AuthModule } from '@/auth/auth.module';
     }),
     AuthModule,
     UsersModule,
+    ProjectsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/projects/dto/create-project.dto.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateProjectDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/apps/backend/src/projects/dto/create-project.dto.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.ts
@@ -1,8 +1,9 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
 
 export class CreateProjectDto {
   @IsString()
   @IsNotEmpty()
+  @Matches(/\S/, { message: 'name must contain non-whitespace characters' })
   name: string;
 
   @IsString()

--- a/apps/backend/src/projects/dto/update-project.dto.ts
+++ b/apps/backend/src/projects/dto/update-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProjectDto } from '@/projects/dto/create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/apps/backend/src/projects/entities/project.entity.ts
+++ b/apps/backend/src/projects/entities/project.entity.ts
@@ -20,11 +20,11 @@ export class Project {
   @Column({ nullable: true })
   description: string;
 
-  @Column()
+  @Column({ name: 'user_id' })
   userId: number;
 
   @ManyToOne(() => User, (user) => user.projects, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'userId' })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/apps/backend/src/projects/entities/project.entity.ts
+++ b/apps/backend/src/projects/entities/project.entity.ts
@@ -1,0 +1,35 @@
+import { User } from '@/users/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity({ name: 'projects' })
+export class Project {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => User, (user) => user.projects, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectsController } from '@/projects/projects.controller';
+import { ProjectsService } from '@/projects/projects.service';
+
+describe('ProjectsController', () => {
+  let controller: ProjectsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProjectsController],
+      providers: [ProjectsService],
+    }).compile();
+
+    controller = module.get<ProjectsController>(ProjectsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ProjectsService } from '@/projects/projects.service';
+import { CreateProjectDto } from '@/projects/dto/create-project.dto';
+import { UpdateProjectDto } from '@/projects/dto/update-project.dto';
+import { JwtAuthGuard } from '@/auth/guards/jwt-auth.guard';
+
+@UseGuards(JwtAuthGuard)
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Post()
+  create(
+    @Body() createProjectDto: CreateProjectDto,
+    @Request() req: { user: { userId: number; email: string } },
+  ) {
+    return this.projectsService.create(createProjectDto, req.user.userId);
+  }
+
+  @Get()
+  findAll(@Request() req: { user: { userId: number; email: string } }) {
+    return this.projectsService.findAll(req.user.userId);
+  }
+
+  @Get(':id')
+  findOne(
+    @Param('id') id: string,
+    @Request() req: { user: { userId: number; email: string } },
+  ) {
+    return this.projectsService.findOne(+id, req.user.userId);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateProjectDto: UpdateProjectDto,
+    @Request() req: { user: { userId: number; email: string } },
+  ) {
+    return this.projectsService.update(+id, updateProjectDto, req.user.userId);
+  }
+
+  @Delete(':id')
+  remove(
+    @Param('id') id: string,
+    @Request() req: { user: { userId: number; email: string } },
+  ) {
+    return this.projectsService.remove(+id, req.user.userId);
+  }
+}

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProjectsService } from '@/projects/projects.service';
+import { ProjectsController } from '@/projects/projects.controller';
+import { Project } from '@/projects/entities/project.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Project])],
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectsService } from '@/projects/projects.service';
+
+describe('ProjectsService', () => {
+  let service: ProjectsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProjectsService],
+    }).compile();
+
+    service = module.get<ProjectsService>(ProjectsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateProjectDto } from '@/projects/dto/create-project.dto';
+import { UpdateProjectDto } from '@/projects/dto/update-project.dto';
+import { Repository } from 'typeorm';
+import { Project } from '@/projects/entities/project.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class ProjectsService {
+  constructor(
+    @InjectRepository(Project)
+    private projectsRepository: Repository<Project>,
+  ) {}
+
+  async create(createProjectDto: CreateProjectDto, userId: number) {
+    const project = this.projectsRepository.create({
+      ...createProjectDto,
+      userId,
+    });
+
+    return await this.projectsRepository.save(project);
+  }
+
+  async findAll(userId: number) {
+    return await this.projectsRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: number, userId: number) {
+    const project = await this.projectsRepository.findOne({
+      where: { id, userId },
+    });
+
+    if (!project) {
+      throw new NotFoundException(
+        `Project with ID "${id}" not found or you don't have access.`,
+      );
+    }
+
+    return project;
+  }
+
+  async update(id: number, updateProjectDto: UpdateProjectDto, userId: number) {
+    const project = await this.findOne(id, userId);
+
+    const updatedProject = this.projectsRepository.merge(
+      project,
+      updateProjectDto,
+    );
+
+    return await this.projectsRepository.save(updatedProject);
+  }
+
+  async remove(id: number, userId: number) {
+    const project = await this.findOne(id, userId);
+
+    return await this.projectsRepository.remove(project);
+  }
+}

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -1,9 +1,11 @@
+import { Project } from '@/projects/entities/project.entity';
 import {
   BeforeInsert,
   BeforeUpdate,
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -35,4 +37,7 @@ export class User {
       this.email = this.email.trim().toLowerCase();
     }
   }
+
+  @OneToMany(() => Project, (project) => project.user)
+  projects: Project[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.1",
-        "@nestjs/mapped-types": "*",
+        "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.1",
+        "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
@@ -5124,6 +5125,26 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {


### PR DESCRIPTION
  - Create ProjectsModule, Controller, and Service using Nest CLI
  - Define Project entity with TypeORM and establish ManyToOne relationship with User
  - Create DTOs with class-validator for creating and updating projects
  - Implement CRUD operations in ProjectsService scoped strictly to the authenticated user's ID
  - Protect all /projects endpoints using JwtAuthGuard

Closes #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full project lifecycle: create, list, view, update, and delete projects with name and optional description, per-user scoping, and automatic timestamps.
  * Endpoints protected by authentication so users only access their own projects.
  * Name field validated to prevent blank/whitespace-only values.

* **Tests**
  * Added unit tests covering project controller and service basic setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->