### PR TITLE
feat(tasks): [#7] Implement Kanban board UI with drag-and-drop

### DIFF
--- a/apps/backend/src/board-columns/board-columns.service.ts
+++ b/apps/backend/src/board-columns/board-columns.service.ts
@@ -90,7 +90,8 @@ export class BoardColumnsService {
     await this.verifyProjectAccess(projectId, userId);
     return await this.columnsRepository.find({
       where: { projectId },
-      order: { order: 'ASC' },
+      relations: { tasks: true },
+      order: { order: 'ASC', tasks: { order: 'ASC' } },
     });
   }
 

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ProjectsService } from '@/projects/projects.service';
 import { ProjectsController } from '@/projects/projects.controller';
 import { Project } from '@/projects/entities/project.entity';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project])],
+  imports: [TypeOrmModule.forFeature([Project, BoardColumn])],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -3,22 +3,32 @@ import { CreateProjectDto } from '@/projects/dto/create-project.dto';
 import { UpdateProjectDto } from '@/projects/dto/update-project.dto';
 import { Repository } from 'typeorm';
 import { Project } from '@/projects/entities/project.entity';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
 import { InjectRepository } from '@nestjs/typeorm';
+
+const DEFAULT_COLUMNS = ['To Do', 'In Progress', 'Done'];
 
 @Injectable()
 export class ProjectsService {
   constructor(
     @InjectRepository(Project)
     private projectsRepository: Repository<Project>,
+    @InjectRepository(BoardColumn)
+    private columnsRepository: Repository<BoardColumn>,
   ) {}
 
   async create(createProjectDto: CreateProjectDto, userId: number) {
-    const project = this.projectsRepository.create({
-      ...createProjectDto,
-      userId,
-    });
+    return await this.projectsRepository.manager.transaction(async (manager) => {
+      const project = manager.create(Project, { ...createProjectDto, userId });
+      await manager.save(project);
 
-    return await this.projectsRepository.save(project);
+      const columns = DEFAULT_COLUMNS.map((name, order) =>
+        manager.create(BoardColumn, { name, order, projectId: project.id }),
+      );
+      await manager.save(columns);
+
+      return project;
+    });
   }
 
   async findAll(userId: number) {
@@ -44,18 +54,12 @@ export class ProjectsService {
 
   async update(id: number, updateProjectDto: UpdateProjectDto, userId: number) {
     const project = await this.findOne(id, userId);
-
-    const updatedProject = this.projectsRepository.merge(
-      project,
-      updateProjectDto,
-    );
-
+    const updatedProject = this.projectsRepository.merge(project, updateProjectDto);
     return await this.projectsRepository.save(updatedProject);
   }
 
   async remove(id: number, userId: number) {
     const project = await this.findOne(id, userId);
-
     return await this.projectsRepository.remove(project);
   }
 }

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -18,17 +18,22 @@ export class ProjectsService {
   ) {}
 
   async create(createProjectDto: CreateProjectDto, userId: number) {
-    return await this.projectsRepository.manager.transaction(async (manager) => {
-      const project = manager.create(Project, { ...createProjectDto, userId });
-      await manager.save(project);
+    return await this.projectsRepository.manager.transaction(
+      async (manager) => {
+        const project = manager.create(Project, {
+          ...createProjectDto,
+          userId,
+        });
+        await manager.save(project);
 
-      const columns = DEFAULT_COLUMNS.map((name, order) =>
-        manager.create(BoardColumn, { name, order, projectId: project.id }),
-      );
-      await manager.save(columns);
+        const columns = DEFAULT_COLUMNS.map((name, order) =>
+          manager.create(BoardColumn, { name, order, projectId: project.id }),
+        );
+        await manager.save(columns);
 
-      return project;
-    });
+        return project;
+      },
+    );
   }
 
   async findAll(userId: number) {
@@ -54,7 +59,10 @@ export class ProjectsService {
 
   async update(id: number, updateProjectDto: UpdateProjectDto, userId: number) {
     const project = await this.findOne(id, userId);
-    const updatedProject = this.projectsRepository.merge(project, updateProjectDto);
+    const updatedProject = this.projectsRepository.merge(
+      project,
+      updateProjectDto,
+    );
     return await this.projectsRepository.save(updatedProject);
   }
 

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -59,7 +59,7 @@ export class TasksService {
       async (transactionalManager) => {
         const column = await transactionalManager
           .createQueryBuilder(BoardColumn, 'column')
-          .leftJoinAndSelect('column.project', 'project')
+          .innerJoinAndSelect('column.project', 'project')
           .where('column.id = :id', { id: createTaskDto.columnId })
           .setLock('pessimistic_write')
           .getOne();
@@ -134,7 +134,7 @@ export class TasksService {
 
           const targetColumn = await transactionalManager
             .createQueryBuilder(BoardColumn, 'column')
-            .leftJoinAndSelect('column.project', 'project')
+            .innerJoinAndSelect('column.project', 'project')
             .where('column.id = :id', { id: updateTaskDto.columnId })
             .setLock('pessimistic_write')
             .getOne();

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -23,6 +23,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/cdk": "^20.2.14",
     "@angular/common": "^20.3.0",
     "@angular/compiler": "^20.3.0",
     "@angular/core": "^20.3.0",

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -4,6 +4,7 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 import { routes } from '@/app/app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -15,5 +16,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideHttpClient(withInterceptors([tokenInterceptor])),
+    provideAnimationsAsync(),
   ],
 };

--- a/apps/frontend/src/app/pages/kanban/kanban.css
+++ b/apps/frontend/src/app/pages/kanban/kanban.css
@@ -1,0 +1,254 @@
+.board-page {
+  height: calc(100vh - 56px);
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.board-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.board {
+  display: flex;
+  gap: 12px;
+  padding: 24px;
+  align-items: flex-start;
+  min-height: 100%;
+  width: max-content;
+}
+
+/* ── Column ───────────────────────────────────────────── */
+.column {
+  width: 272px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 56px - 48px);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 10px 8px;
+  flex-shrink: 0;
+}
+
+.column-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.column-name-input {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 4px 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.column-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+/* ── Column body (drop zone) ──────────────────────────── */
+.column-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px;
+  min-height: 48px;
+}
+
+.column-empty {
+  padding: 12px 8px;
+  text-align: center;
+  font-size: var(--text-xs);
+  color: var(--color-text-placeholder);
+}
+
+/* ── Task card ────────────────────────────────────────── */
+.task-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 10px 10px 8px;
+  margin-bottom: 8px;
+  cursor: grab;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.task-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+}
+
+.task-card:active {
+  cursor: grabbing;
+}
+
+.task-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.task-desc {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: 4px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.task-card-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.task-card:hover .task-card-actions {
+  opacity: 1;
+}
+
+/* CDK drag states */
+.task-placeholder {
+  height: 60px;
+  background-color: var(--color-accent-bg);
+  border: 2px dashed var(--color-accent);
+  border-radius: var(--radius-sm);
+  margin-bottom: 8px;
+}
+
+.cdk-drag-animating {
+  transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.column-body.cdk-drop-list-dragging .task-card:not(.cdk-drag-placeholder) {
+  transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.cdk-drag-preview {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  padding: 10px 10px 8px;
+  box-shadow: var(--shadow-lg);
+  cursor: grabbing;
+}
+
+/* ── Column footer / add task ─────────────────────────── */
+.column-footer {
+  padding: 4px 8px 8px;
+  flex-shrink: 0;
+}
+
+.add-task-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+  text-align: left;
+}
+
+.add-task-btn:hover {
+  background-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.add-task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.add-task-input {
+  font-size: var(--text-sm);
+  resize: none;
+  min-height: unset;
+}
+
+.add-task-form-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Add column ───────────────────────────────────────── */
+.add-column {
+  flex-shrink: 0;
+  width: 240px;
+}
+
+.add-column-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background-color: rgba(255, 255, 255, 0.6);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.add-column-btn:hover {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-accent);
+}
+
+.add-column-form {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.add-column-form-actions {
+  display: flex;
+  gap: 6px;
+}

--- a/apps/frontend/src/app/pages/kanban/kanban.html
+++ b/apps/frontend/src/app/pages/kanban/kanban.html
@@ -18,7 +18,6 @@
                 (keydown.enter)="confirmRenameColumn(col)"
                 (keydown.escape)="cancelRenameColumn()"
                 (blur)="confirmRenameColumn(col)"
-                autofocus
               />
             } @else {
               <span class="column-name">{{ col.name }}</span>
@@ -94,7 +93,6 @@
                   rows="2"
                   (keydown.enter)="$event.preventDefault(); confirmAddTask(col)"
                   (keydown.escape)="cancelAddTask()"
-                  autofocus
                 ></textarea>
                 <div class="add-task-form-actions">
                   <button class="btn btn-primary" style="font-size:12px;padding:6px 12px" (click)="confirmAddTask(col)">Add</button>
@@ -124,7 +122,6 @@
               placeholder="Column name…"
               (keydown.enter)="confirmAddColumn()"
               (keydown.escape)="addingColumn = false"
-              autofocus
             />
             <div class="add-column-form-actions">
               <button class="btn btn-primary" style="font-size:12px;padding:6px 12px" (click)="confirmAddColumn()">Add</button>

--- a/apps/frontend/src/app/pages/kanban/kanban.html
+++ b/apps/frontend/src/app/pages/kanban/kanban.html
@@ -1,7 +1,188 @@
-<app-nav [title]="'Project ' + projectId" />
+<app-nav [title]="projectName" />
 
-<main style="padding: 32px 24px">
-  <p style="color: var(--color-text-muted); font-size: var(--text-sm)">
-    Kanban board for project #{{ projectId }} — coming soon.
-  </p>
+<main class="board-page">
+  @if (loading) {
+    <div class="board-center"><div class="spinner"></div></div>
+  } @else {
+    <div class="board" cdkDropListGroup>
+
+      @for (col of columns; track col.id) {
+        <div class="column">
+
+          <!-- Column header -->
+          <div class="column-header">
+            @if (editingColumnId === col.id) {
+              <input
+                class="column-name-input form-input"
+                [(ngModel)]="editingColumnName"
+                (keydown.enter)="confirmRenameColumn(col)"
+                (keydown.escape)="cancelRenameColumn()"
+                (blur)="confirmRenameColumn(col)"
+                autofocus
+              />
+            } @else {
+              <span class="column-name">{{ col.name }}</span>
+              <div class="column-actions">
+                <button class="btn-icon" (click)="startRenameColumn(col)" aria-label="Rename column" title="Rename">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                  </svg>
+                </button>
+                <button class="btn-icon danger" (click)="deleteColumn(col)" aria-label="Delete column" title="Delete">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="3 6 5 6 21 6"/>
+                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                    <path d="M10 11v6M14 11v6"/>
+                    <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                  </svg>
+                </button>
+              </div>
+            }
+          </div>
+
+          <!-- Task list (drop zone) -->
+          <div
+            class="column-body"
+            cdkDropList
+            [id]="'' + col.id"
+            [cdkDropListData]="col.tasks"
+            (cdkDropListDropped)="onTaskDrop($event)"
+          >
+            @for (task of col.tasks; track task.id) {
+              <div class="task-card" cdkDrag>
+                <div class="task-card-content">
+                  <p class="task-title">{{ task.title }}</p>
+                  @if (task.description) {
+                    <p class="task-desc">{{ task.description }}</p>
+                  }
+                </div>
+                <div class="task-card-actions">
+                  <button class="btn-icon" (click)="startEditTask(task)" aria-label="Edit task" title="Edit">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                    </svg>
+                  </button>
+                  <button class="btn-icon danger" (click)="deleteTask(task, col)" aria-label="Delete task" title="Delete">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <polyline points="3 6 5 6 21 6"/>
+                      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                      <path d="M10 11v6M14 11v6"/>
+                      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                    </svg>
+                  </button>
+                </div>
+                <!-- Drag placeholder -->
+                <div *cdkDragPlaceholder class="task-placeholder"></div>
+              </div>
+            }
+
+            @if (col.tasks.length === 0) {
+              <div class="column-empty">No tasks yet</div>
+            }
+          </div>
+
+          <!-- Add task -->
+          <div class="column-footer">
+            @if (addingTaskInColumnId === col.id) {
+              <div class="add-task-form">
+                <textarea
+                  class="form-textarea add-task-input"
+                  [(ngModel)]="newTaskTitle"
+                  placeholder="Task title…"
+                  rows="2"
+                  (keydown.enter)="$event.preventDefault(); confirmAddTask(col)"
+                  (keydown.escape)="cancelAddTask()"
+                  autofocus
+                ></textarea>
+                <div class="add-task-form-actions">
+                  <button class="btn btn-primary" style="font-size:12px;padding:6px 12px" (click)="confirmAddTask(col)">Add</button>
+                  <button class="btn btn-ghost" style="font-size:12px;padding:6px 12px" (click)="cancelAddTask()">Cancel</button>
+                </div>
+              </div>
+            } @else {
+              <button class="add-task-btn" (click)="openAddTask(col.id)">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 5v14M5 12h14"/>
+                </svg>
+                Add task
+              </button>
+            }
+          </div>
+
+        </div>
+      }
+
+      <!-- Add column -->
+      <div class="add-column">
+        @if (addingColumn) {
+          <div class="add-column-form card">
+            <input
+              class="form-input"
+              [(ngModel)]="newColumnName"
+              placeholder="Column name…"
+              (keydown.enter)="confirmAddColumn()"
+              (keydown.escape)="addingColumn = false"
+              autofocus
+            />
+            <div class="add-column-form-actions">
+              <button class="btn btn-primary" style="font-size:12px;padding:6px 12px" (click)="confirmAddColumn()">Add</button>
+              <button class="btn btn-ghost" style="font-size:12px;padding:6px 12px" (click)="addingColumn = false">Cancel</button>
+            </div>
+          </div>
+        } @else {
+          <button class="add-column-btn" (click)="startAddColumn()">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 5v14M5 12h14"/>
+            </svg>
+            Add column
+          </button>
+        }
+      </div>
+
+    </div>
+  }
 </main>
+
+<!-- Edit task modal -->
+@if (editingTask) {
+  <div class="modal-backdrop">
+    <div class="modal">
+      <div class="modal-header">
+        <h2 class="modal-title">Edit Task</h2>
+        <button class="btn-icon" (click)="cancelEditTask()" aria-label="Close">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6L6 18M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-label" for="task-title">Title</label>
+          <input
+            id="task-title"
+            class="form-input"
+            [(ngModel)]="editingTaskTitle"
+            (keydown.enter)="confirmEditTask()"
+            placeholder="Task title"
+          />
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="task-desc">Description</label>
+          <textarea
+            id="task-desc"
+            class="form-textarea"
+            [(ngModel)]="editingTaskDescription"
+            placeholder="Optional description…"
+            rows="3"
+          ></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-ghost" (click)="cancelEditTask()">Cancel</button>
+        <button class="btn btn-primary" (click)="confirmEditTask()" [disabled]="!editingTaskTitle.trim()">Save</button>
+      </div>
+    </div>
+  </div>
+}

--- a/apps/frontend/src/app/pages/kanban/kanban.ts
+++ b/apps/frontend/src/app/pages/kanban/kanban.ts
@@ -1,17 +1,242 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, HostListener, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+import { CdkDrag, CdkDragDrop, CdkDragPlaceholder, CdkDropList, CdkDropListGroup, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
 import { Nav } from '@/app/shared/nav/nav';
+import { BoardColumnService } from '@/app/projects/board-column.service';
+import { TaskService } from '@/app/projects/task.service';
+import { ProjectService } from '@/app/projects/project.service';
+import { Project } from '@/app/projects/project.model';
+import { BoardColumn } from '@/app/projects/board-column.model';
+import { Task } from '@/app/projects/task.model';
 
 @Component({
   selector: 'app-kanban',
-  imports: [Nav],
+  imports: [CommonModule, FormsModule, Nav, CdkDropListGroup, CdkDropList, CdkDrag, CdkDragPlaceholder],
   templateUrl: './kanban.html',
+  styleUrl: './kanban.css',
 })
 export class Kanban implements OnInit {
   private route = inject(ActivatedRoute);
-  projectId: string | null = null;
+  private boardColumnService = inject(BoardColumnService);
+  private taskService = inject(TaskService);
+  private projectService = inject(ProjectService);
+
+  projectId!: number;
+  projectName = '';
+  columns: BoardColumn[] = [];
+  loading = true;
+
+  // Column management
+  editingColumnId: number | null = null;
+  editingColumnName = '';
+  addingColumn = false;
+  newColumnName = '';
+
+  // Task management
+  addingTaskInColumnId: number | null = null;
+  newTaskTitle = '';
+  editingTask: Task | null = null;
+  editingTaskTitle = '';
+  editingTaskDescription = '';
 
   ngOnInit() {
-    this.projectId = this.route.snapshot.paramMap.get('id');
+    this.projectId = Number(this.route.snapshot.paramMap.get('id'));
+    this.projectService.getProject(this.projectId).subscribe({
+      next: (project: Project) => {
+        this.projectName = project.name;
+      },
+    });
+    this.loadBoard();
+  }
+
+  loadBoard() {
+    this.loading = true;
+    this.boardColumnService.getColumns(this.projectId).subscribe({
+      next: (columns) => {
+        this.columns = columns;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      },
+    });
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape() {
+    if (this.editingTask) this.cancelEditTask();
+  }
+
+  // ── Drag & Drop ────────────────────────────────────────────────────
+  onTaskDrop(event: CdkDragDrop<Task[]>) {
+    const task = event.previousContainer.data[event.previousIndex];
+    const newColumnId = Number(event.container.id);
+
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex,
+      );
+    }
+
+    this.taskService
+      .updateTask(task.id, { columnId: newColumnId, order: event.currentIndex })
+      .subscribe({
+        error: () => {
+          if (event.previousContainer === event.container) {
+            moveItemInArray(event.container.data, event.currentIndex, event.previousIndex);
+          } else {
+            transferArrayItem(
+              event.container.data,
+              event.previousContainer.data,
+              event.currentIndex,
+              event.previousIndex,
+            );
+          }
+        },
+      });
+  }
+
+  // ── Column CRUD ────────────────────────────────────────────────────
+  startAddColumn() {
+    this.addingColumn = true;
+    this.newColumnName = '';
+  }
+
+  confirmAddColumn() {
+    const name = this.newColumnName.trim();
+    if (!name) {
+      this.addingColumn = false;
+      return;
+    }
+    this.boardColumnService.createColumn({ name, projectId: this.projectId }).subscribe({
+      next: (col) => {
+        this.columns = [...this.columns, { ...col, tasks: [] }];
+        this.addingColumn = false;
+        this.newColumnName = '';
+      },
+      error: () => {
+        alert('Failed to add column. Please try again.');
+      },
+    });
+  }
+
+  startRenameColumn(col: BoardColumn) {
+    this.editingColumnId = col.id;
+    this.editingColumnName = col.name;
+  }
+
+  confirmRenameColumn(col: BoardColumn) {
+    const name = this.editingColumnName.trim();
+    if (!name || name === col.name) {
+      this.editingColumnId = null;
+      return;
+    }
+    this.boardColumnService.updateColumn(col.id, { name }).subscribe({
+      next: (updated) => {
+        this.columns = this.columns.map((c) => (c.id === col.id ? { ...updated, tasks: c.tasks } : c));
+        this.editingColumnId = null;
+      },
+      error: () => {
+        this.editingColumnId = null;
+        alert('Failed to rename column. Please try again.');
+      },
+    });
+  }
+
+  cancelRenameColumn() {
+    this.editingColumnId = null;
+  }
+
+  deleteColumn(col: BoardColumn) {
+    const msg = col.tasks.length
+      ? `Delete "${col.name}"? This will also delete its ${col.tasks.length} task(s). This cannot be undone.`
+      : `Delete "${col.name}"? This cannot be undone.`;
+    if (!confirm(msg)) return;
+    this.boardColumnService.deleteColumn(col.id).subscribe({
+      next: () => {
+        this.columns = this.columns.filter((c) => c.id !== col.id);
+      },
+      error: () => {
+        alert(`Failed to delete "${col.name}". Please try again.`);
+      },
+    });
+  }
+
+  // ── Task CRUD ──────────────────────────────────────────────────────
+  openAddTask(columnId: number) {
+    this.addingTaskInColumnId = columnId;
+    this.newTaskTitle = '';
+  }
+
+  confirmAddTask(col: BoardColumn) {
+    const title = this.newTaskTitle.trim();
+    if (!title) {
+      this.addingTaskInColumnId = null;
+      return;
+    }
+    this.taskService.createTask({ title, columnId: col.id }).subscribe({
+      next: (task) => {
+        col.tasks = [...col.tasks, task];
+        this.addingTaskInColumnId = null;
+        this.newTaskTitle = '';
+      },
+      error: () => {
+        alert('Failed to add task. Please try again.');
+      },
+    });
+  }
+
+  cancelAddTask() {
+    this.addingTaskInColumnId = null;
+  }
+
+  startEditTask(task: Task) {
+    this.editingTask = task;
+    this.editingTaskTitle = task.title;
+    this.editingTaskDescription = task.description ?? '';
+  }
+
+  confirmEditTask() {
+    if (!this.editingTask) return;
+    const title = this.editingTaskTitle.trim();
+    if (!title) return;
+    this.taskService
+      .updateTask(this.editingTask.id, { title, description: this.editingTaskDescription.trim() || undefined })
+      .subscribe({
+        next: (updated) => {
+          this.columns = this.columns.map((col) => ({
+            ...col,
+            tasks: col.tasks.map((t) => (t.id === updated.id ? updated : t)),
+          }));
+          this.editingTask = null;
+        },
+        error: () => {
+          this.editingTask = null;
+          alert('Failed to update task. Please try again.');
+        },
+      });
+  }
+
+  cancelEditTask() {
+    this.editingTask = null;
+  }
+
+  deleteTask(task: Task, col: BoardColumn) {
+    if (!confirm(`Delete "${task.title}"?`)) return;
+    this.taskService.deleteTask(task.id).subscribe({
+      next: () => {
+        col.tasks = col.tasks.filter((t) => t.id !== task.id);
+      },
+      error: () => {
+        alert(`Failed to delete "${task.title}". Please try again.`);
+      },
+    });
   }
 }

--- a/apps/frontend/src/app/projects/board-column.model.ts
+++ b/apps/frontend/src/app/projects/board-column.model.ts
@@ -1,0 +1,21 @@
+import { Task } from './task.model';
+
+export interface BoardColumn {
+  id: number;
+  name: string;
+  order: number;
+  projectId: number;
+  tasks: Task[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateBoardColumnDto {
+  name: string;
+  projectId: number;
+}
+
+export interface UpdateBoardColumnDto {
+  name?: string;
+  order?: number;
+}

--- a/apps/frontend/src/app/projects/board-column.service.ts
+++ b/apps/frontend/src/app/projects/board-column.service.ts
@@ -1,0 +1,29 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '@/environments/environment';
+import { BoardColumn, CreateBoardColumnDto, UpdateBoardColumnDto } from './board-column.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BoardColumnService {
+  private httpClient = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/board-columns`;
+
+  getColumns(projectId: number): Observable<BoardColumn[]> {
+    return this.httpClient.get<BoardColumn[]>(this.apiUrl, { params: { projectId } });
+  }
+
+  createColumn(dto: CreateBoardColumnDto): Observable<BoardColumn> {
+    return this.httpClient.post<BoardColumn>(this.apiUrl, dto);
+  }
+
+  updateColumn(id: number, dto: UpdateBoardColumnDto): Observable<BoardColumn> {
+    return this.httpClient.patch<BoardColumn>(`${this.apiUrl}/${id}`, dto);
+  }
+
+  deleteColumn(id: number): Observable<void> {
+    return this.httpClient.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/apps/frontend/src/app/projects/project.service.ts
+++ b/apps/frontend/src/app/projects/project.service.ts
@@ -15,6 +15,10 @@ export class ProjectService {
     return this.httpClient.get<Project[]>(this.apiUrl);
   }
 
+  getProject(id: number): Observable<Project> {
+    return this.httpClient.get<Project>(`${this.apiUrl}/${id}`);
+  }
+
   createProject(dto: CreateProjectDto): Observable<Project> {
     return this.httpClient.post<Project>(this.apiUrl, dto);
   }

--- a/apps/frontend/src/app/projects/task.model.ts
+++ b/apps/frontend/src/app/projects/task.model.ts
@@ -1,0 +1,22 @@
+export interface Task {
+  id: number;
+  title: string;
+  description: string | null;
+  order: number;
+  columnId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTaskDto {
+  title: string;
+  description?: string;
+  columnId: number;
+}
+
+export interface UpdateTaskDto {
+  title?: string;
+  description?: string;
+  columnId?: number;
+  order?: number;
+}

--- a/apps/frontend/src/app/projects/task.service.ts
+++ b/apps/frontend/src/app/projects/task.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '@/environments/environment';
+import { CreateTaskDto, Task, UpdateTaskDto } from './task.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TaskService {
+  private httpClient = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/tasks`;
+
+  createTask(dto: CreateTaskDto): Observable<Task> {
+    return this.httpClient.post<Task>(this.apiUrl, dto);
+  }
+
+  updateTask(id: number, dto: UpdateTaskDto): Observable<Task> {
+    return this.httpClient.patch<Task>(`${this.apiUrl}/${id}`, dto);
+  }
+
+  deleteTask(id: number): Observable<void> {
+    return this.httpClient.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/apps/frontend/src/app/shared/nav/nav.ts
+++ b/apps/frontend/src/app/shared/nav/nav.ts
@@ -16,10 +16,11 @@ export class Nav {
   private elementRef = inject(ElementRef);
 
   menuOpen = false;
+  readonly userInitial: string;
 
-  get userInitial(): string {
+  constructor() {
     const email = this.authService.getUserEmail();
-    return email ? email[0].toUpperCase() : '?';
+    this.userInitial = email ? email[0].toUpperCase() : '?';
   }
 
   @HostListener('document:click', ['$event'])

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
     "apps/frontend": {
       "version": "0.0.0",
       "dependencies": {
+        "@angular/cdk": "^20.2.14",
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",
         "@angular/core": "^20.3.0",
@@ -1183,6 +1184,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "20.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.14.tgz",
+      "integrity": "sha512-7bZxc01URbiPiIBWThQ69XwOxVduqEKN4PhpbF2AAyfMc/W8Hcr4VoIJOwL0O1Nkq5beS8pCAqoOeIgFyXd/kg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -16616,7 +16632,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -16670,7 +16685,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"


### PR DESCRIPTION
**Summary**

- Kanban board UI — full board implementation replacing the coming soon scaffold. Columns render as scrollable lanes; tasks are displayed as cards with title and optional description preview.
- Drag-and-drop — tasks can be moved within and between columns using Angular CDK. The UI updates optimistically on drop; if the API call fails, the move is automatically reversed so the board stays in sync with the server.
- Column CRUD — inline rename (Enter/Escape/blur to confirm), delete with task-count warning, and an "Add column" form at the end of the board. All mutations surface an error message on failure.
- Task CRUD — inline "Add task" form per column, edit modal (title + description), and delete with confirmation. All mutations surface an error message on failure.
- Default columns on project creation — creating a project now auto-seeds three columns ("To Do", "In Progress", "Done") inside a transaction, so every new board is immediately usable.

**Backend changes**

- projects.service.ts — create() wrapped in a transaction that seeds default BoardColumn rows; BoardColumn repository injected via ProjectsModule.
- board-columns.service.ts — findByProject now eager-loads tasks with relations: { tasks: true } and orders them by tasks.order ASC, delivering the full board state in a single query.
- tasks.service.ts — leftJoinAndSelect → innerJoinAndSelect for the project relation on task create/move; a column without a parent project is invalid, not a nullable case.

**Post-review fixes**

- Edit task modal Escape key moved from an unfocused backdrop attribute to @HostListener('document:keydown.escape') on the component, guarded by if (this.editingTask).
- onTaskDrop now reverts the CDK move (moveItemInArray / transferArrayItem) on API error, preventing board state from drifting out of sync with the server.
- All six mutating operations (deleteColumn, deleteTask, confirmAddColumn, confirmRenameColumn, confirmAddTask, confirmEditTask) have error callbacks.
- userInitial in Nav moved from a getter (re-evaluated every change-detection pass) to a constructor-cached readonly field.
- Kanban nav breadcrumb now shows the real project name, fetched via the new ProjectService.getProject(id) method, instead of the raw project ID.

Closes #7 