### PR TITLE
test(app): add comprehensive test coverage to both frontend and backe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 > Changes on `main` not yet tagged as a release.
 
+### Added
+
+**Tests**
+- Backend: 102 Jest unit tests across all modules — `auth`, `users`, `projects`, `board-columns`, `tasks` — covering services and controllers
+- Frontend: 126 Karma + Jasmine unit tests covering all components (`Login`, `Register`, `Nav`, `ProjectForm`, `Dashboard`, `Kanban`), all services (`Auth`, `ProjectService`, `BoardColumnService`, `TaskService`), `AuthGuard`, and `TokenInterceptor`
+
+### Fixed
+
+- `tsconfig.json` (`backend` and `frontend`): removed deprecated `baseUrl`, added explicit `rootDir`, dropped `../../libs/**/*` from backend `include` — fixes TypeScript language server errors in editors
+
 ---
 
 ## [1.0.0] - 2026-04-26

--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ npm run start:frontend
 # App running at http://localhost:4200
 ```
 
+## 🧪 Running Tests
+
+```bash
+# Backend — Jest unit tests (102 tests)
+cd apps/backend && npm test
+
+# Backend — watch mode
+cd apps/backend && npm run test:watch
+
+# Backend — coverage report
+cd apps/backend && npm run test:cov
+
+# Frontend — Karma + Jasmine (126 tests)
+cd apps/frontend && ng test
+
+# Frontend — single run (CI)
+cd apps/frontend && ng test --watch=false --browsers=ChromeHeadless
+```
+
 ## 🔧 Environment Variables
 
 Create `apps/backend/.env` with the following variables:

--- a/apps/backend/src/board-columns/board-columns.controller.spec.ts
+++ b/apps/backend/src/board-columns/board-columns.controller.spec.ts
@@ -1,6 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { BoardColumnsController } from '@/board-columns/board-columns.controller';
 import { BoardColumnsService } from '@/board-columns/board-columns.service';
+import { CreateBoardColumnDto } from '@/board-columns/dto/create-board-column.dto';
+import { UpdateBoardColumnDto } from '@/board-columns/dto/update-board-column.dto';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+const PROJECT_ID = 10;
+const COLUMN_ID = 20;
+
+const mockReq = { user: { userId: USER_ID, email: 'user@test.com' } };
+
+const mockColumn = (): BoardColumn =>
+  ({
+    id: COLUMN_ID,
+    name: 'To Do',
+    order: 0,
+    projectId: PROJECT_ID,
+    tasks: [],
+  }) as unknown as BoardColumn;
+
+// ── Mock service ──────────────────────────────────────────────────────────────
+
+const mockBoardColumnsService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('BoardColumnsController', () => {
   let controller: BoardColumnsController;
@@ -8,13 +41,183 @@ describe('BoardColumnsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [BoardColumnsController],
-      providers: [BoardColumnsService],
+      providers: [
+        {
+          provide: BoardColumnsService,
+          useValue: mockBoardColumnsService,
+        },
+      ],
     }).compile();
 
     controller = module.get<BoardColumnsController>(BoardColumnsController);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should delegate to BoardColumnsService.create with dto and userId', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = {
+        name: 'Backlog',
+        projectId: PROJECT_ID,
+      };
+      const column = mockColumn();
+      mockBoardColumnsService.create.mockResolvedValue(column);
+
+      // Act
+      const result = await controller.create(dto, mockReq);
+
+      // Assert
+      expect(mockBoardColumnsService.create).toHaveBeenCalledWith(dto, USER_ID);
+      expect(result).toEqual(column);
+    });
+
+    it('should propagate ForbiddenException from the service', async () => {
+      // Arrange
+      mockBoardColumnsService.create.mockRejectedValue(
+        new ForbiddenException(),
+      );
+
+      // Act & Assert
+      await expect(
+        controller.create({ name: 'X', projectId: 999 }, mockReq),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should delegate to BoardColumnsService.findAll with projectId and userId', async () => {
+      // Arrange
+      const columns = [mockColumn()];
+      mockBoardColumnsService.findAll.mockResolvedValue(columns);
+
+      // Act
+      const result = await controller.findAll(PROJECT_ID, mockReq);
+
+      // Assert
+      expect(mockBoardColumnsService.findAll).toHaveBeenCalledWith(
+        PROJECT_ID,
+        USER_ID,
+      );
+      expect(result).toEqual(columns);
+    });
+
+    it('should propagate NotFoundException when the project does not exist', async () => {
+      // Arrange
+      mockBoardColumnsService.findAll.mockRejectedValue(
+        new NotFoundException(),
+      );
+
+      // Act & Assert
+      await expect(controller.findAll(999, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should delegate to BoardColumnsService.findOne with id and userId', async () => {
+      // Arrange
+      const column = mockColumn();
+      mockBoardColumnsService.findOne.mockResolvedValue(column);
+
+      // Act
+      const result = await controller.findOne(COLUMN_ID, mockReq);
+
+      // Assert
+      expect(mockBoardColumnsService.findOne).toHaveBeenCalledWith(
+        COLUMN_ID,
+        USER_ID,
+      );
+      expect(result).toEqual(column);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      // Arrange
+      mockBoardColumnsService.findOne.mockRejectedValue(
+        new NotFoundException(),
+      );
+
+      // Act & Assert
+      await expect(controller.findOne(999, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should delegate to BoardColumnsService.update with id, dto, and userId', async () => {
+      // Arrange
+      const dto: UpdateBoardColumnDto = { name: 'In Review' };
+      const updated = { ...mockColumn(), name: 'In Review' } as BoardColumn;
+      mockBoardColumnsService.update.mockResolvedValue(updated);
+
+      // Act
+      const result = await controller.update(COLUMN_ID, dto, mockReq);
+
+      // Assert
+      expect(mockBoardColumnsService.update).toHaveBeenCalledWith(
+        COLUMN_ID,
+        dto,
+        USER_ID,
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it('should propagate ForbiddenException from the service', async () => {
+      // Arrange
+      mockBoardColumnsService.update.mockRejectedValue(
+        new ForbiddenException(),
+      );
+
+      // Act & Assert
+      await expect(
+        controller.update(COLUMN_ID, {}, mockReq),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should delegate to BoardColumnsService.remove with id and userId', async () => {
+      // Arrange
+      const column = mockColumn();
+      mockBoardColumnsService.remove.mockResolvedValue(column);
+
+      // Act
+      const result = await controller.remove(COLUMN_ID, mockReq);
+
+      // Assert
+      expect(mockBoardColumnsService.remove).toHaveBeenCalledWith(
+        COLUMN_ID,
+        USER_ID,
+      );
+      expect(result).toEqual(column);
+    });
+
+    it('should propagate ForbiddenException from the service', async () => {
+      // Arrange
+      mockBoardColumnsService.remove.mockRejectedValue(
+        new ForbiddenException(),
+      );
+
+      // Act & Assert
+      await expect(
+        controller.remove(COLUMN_ID, mockReq),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
   });
 });

--- a/apps/backend/src/board-columns/board-columns.service.spec.ts
+++ b/apps/backend/src/board-columns/board-columns.service.spec.ts
@@ -1,18 +1,395 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { BoardColumnsService } from '@/board-columns/board-columns.service';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
+import { Project } from '@/projects/entities/project.entity';
+import { CreateBoardColumnDto } from '@/board-columns/dto/create-board-column.dto';
+import { UpdateBoardColumnDto } from '@/board-columns/dto/update-board-column.dto';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+const OTHER_USER_ID = 99;
+const PROJECT_ID = 10;
+const COLUMN_ID = 20;
+
+const mockProject = (): Project =>
+  ({ id: PROJECT_ID, userId: USER_ID }) as Project;
+
+const mockColumn = (): BoardColumn =>
+  ({
+    id: COLUMN_ID,
+    name: 'To Do',
+    order: 0,
+    projectId: PROJECT_ID,
+    project: mockProject(),
+    tasks: [],
+  }) as unknown as BoardColumn;
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockQueryBuilder = {
+  where: jest.fn().mockReturnThis(),
+  setLock: jest.fn().mockReturnThis(),
+  getOne: jest.fn(),
+};
+
+const mockTransactionalManager = {
+  createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockColumnsRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  merge: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+  manager: {
+    transaction: jest.fn(),
+  },
+};
+
+const mockProjectsRepository = {
+  findOne: jest.fn(),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('BoardColumnsService', () => {
   let service: BoardColumnsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BoardColumnsService],
+      providers: [
+        BoardColumnsService,
+        {
+          provide: getRepositoryToken(BoardColumn),
+          useValue: mockColumnsRepository,
+        },
+        {
+          provide: getRepositoryToken(Project),
+          useValue: mockProjectsRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<BoardColumnsService>(BoardColumnsService);
+
+    jest.clearAllMocks();
+
+    // Default: transaction executes the callback immediately
+    mockColumnsRepository.manager.transaction.mockImplementation(
+      async (
+        cb: (m: typeof mockTransactionalManager) => Promise<BoardColumn>,
+      ) => cb(mockTransactionalManager),
+    );
+    // Default: queryBuilder is set up on the transactional manager
+    mockTransactionalManager.createQueryBuilder.mockReturnValue(
+      mockQueryBuilder,
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create a column with auto-assigned order (first column, order = 0)', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = {
+        name: 'Backlog',
+        projectId: PROJECT_ID,
+      };
+      const project = mockProject();
+      const column = { ...mockColumn(), name: 'Backlog', order: 0 };
+
+      mockQueryBuilder.getOne.mockResolvedValue(project);
+      mockTransactionalManager.findOne.mockResolvedValue(null); // no existing columns
+      mockTransactionalManager.create.mockReturnValue(column);
+      mockTransactionalManager.save.mockResolvedValue(column);
+
+      // Act
+      const result = await service.create(dto, USER_ID);
+
+      // Assert
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({ name: 'Backlog', order: 0 }),
+      );
+      expect(result).toEqual(column);
+    });
+
+    it('should auto-assign order as last column order + 1', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = {
+        name: 'Review',
+        projectId: PROJECT_ID,
+      };
+      const project = mockProject();
+      const lastColumn = { order: 2 };
+      const column = { ...mockColumn(), name: 'Review', order: 3 };
+
+      mockQueryBuilder.getOne.mockResolvedValue(project);
+      mockTransactionalManager.findOne.mockResolvedValue(lastColumn);
+      mockTransactionalManager.create.mockReturnValue(column);
+      mockTransactionalManager.save.mockResolvedValue(column);
+
+      // Act
+      const result = await service.create(dto, USER_ID);
+
+      // Assert
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({ order: 3 }),
+      );
+      expect(result).toEqual(column);
+    });
+
+    it('should use the provided order when explicitly supplied', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = {
+        name: 'QA',
+        projectId: PROJECT_ID,
+        order: 1,
+      };
+      const project = mockProject();
+      const column = { ...mockColumn(), name: 'QA', order: 1 };
+
+      mockQueryBuilder.getOne.mockResolvedValue(project);
+      mockTransactionalManager.create.mockReturnValue(column);
+      mockTransactionalManager.save.mockResolvedValue(column);
+
+      // Act
+      const result = await service.create(dto, USER_ID);
+
+      // Assert
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({ order: 1 }),
+      );
+      expect(mockTransactionalManager.findOne).not.toHaveBeenCalled();
+      expect(result).toEqual(column);
+    });
+
+    it('should throw NotFoundException when the project does not exist', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = { name: 'Backlog', projectId: 999 };
+      mockQueryBuilder.getOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.create(dto, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when the project is owned by another user', async () => {
+      // Arrange
+      const dto: CreateBoardColumnDto = {
+        name: 'Backlog',
+        projectId: PROJECT_ID,
+      };
+      const project = { ...mockProject(), userId: OTHER_USER_ID };
+      mockQueryBuilder.getOne.mockResolvedValue(project);
+
+      // Act & Assert
+      await expect(service.create(dto, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should return columns with tasks for the project', async () => {
+      // Arrange
+      const project = mockProject();
+      const columns = [mockColumn()];
+      mockProjectsRepository.findOne.mockResolvedValue(project);
+      mockColumnsRepository.find.mockResolvedValue(columns);
+
+      // Act
+      const result = await service.findAll(PROJECT_ID, USER_ID);
+
+      // Assert
+      expect(mockColumnsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { projectId: PROJECT_ID },
+          relations: { tasks: true },
+          order: { order: 'ASC', tasks: { order: 'ASC' } },
+        }),
+      );
+      expect(result).toEqual(columns);
+    });
+
+    it('should throw NotFoundException when the project does not exist', async () => {
+      // Arrange
+      mockProjectsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findAll(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when the project is owned by another user', async () => {
+      // Arrange
+      const project = { ...mockProject(), userId: OTHER_USER_ID };
+      mockProjectsRepository.findOne.mockResolvedValue(project);
+
+      // Act & Assert
+      await expect(service.findAll(PROJECT_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should return the column when it exists and is owned by the user', async () => {
+      // Arrange
+      const column = mockColumn();
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+
+      // Act
+      const result = await service.findOne(COLUMN_ID, USER_ID);
+
+      // Assert
+      expect(mockColumnsRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: COLUMN_ID } }),
+      );
+      expect(result).toEqual(column);
+    });
+
+    it('should throw NotFoundException when the column does not exist', async () => {
+      // Arrange
+      mockColumnsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findOne(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it("should throw ForbiddenException when the column belongs to another user's project", async () => {
+      // Arrange
+      const column = {
+        ...mockColumn(),
+        project: { id: PROJECT_ID, userId: OTHER_USER_ID },
+      };
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+
+      // Act & Assert
+      await expect(service.findOne(COLUMN_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should update and return the column', async () => {
+      // Arrange
+      const column = mockColumn();
+      const dto: UpdateBoardColumnDto = { name: 'In Review' };
+      const updated = { ...column, name: 'In Review' } as BoardColumn;
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+      mockColumnsRepository.merge.mockReturnValue(updated);
+      mockColumnsRepository.save.mockResolvedValue(updated);
+
+      // Act
+      const result = await service.update(COLUMN_ID, dto, USER_ID);
+
+      // Assert
+      expect(mockColumnsRepository.merge).toHaveBeenCalledWith(column, dto);
+      expect(mockColumnsRepository.save).toHaveBeenCalledWith(updated);
+      expect(result).toEqual(updated);
+    });
+
+    it('should strip projectId from the update payload', async () => {
+      // Arrange
+      const column = mockColumn();
+      const dto = { name: 'Done', projectId: 999 } as UpdateBoardColumnDto & {
+        projectId?: number;
+      };
+      const updated = { ...column, name: 'Done' } as BoardColumn;
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+      mockColumnsRepository.merge.mockReturnValue(updated);
+      mockColumnsRepository.save.mockResolvedValue(updated);
+
+      // Act
+      await service.update(COLUMN_ID, dto, USER_ID);
+
+      // Assert — projectId must not be in what is merged
+      expect(mockColumnsRepository.merge).toHaveBeenCalledWith(
+        column,
+        expect.not.objectContaining({ projectId: 999 }),
+      );
+    });
+
+    it('should throw ForbiddenException when the column is not owned by the user', async () => {
+      // Arrange
+      const column = {
+        ...mockColumn(),
+        project: { id: PROJECT_ID, userId: OTHER_USER_ID },
+      };
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+
+      // Act & Assert
+      await expect(
+        service.update(COLUMN_ID, { name: 'X' }, USER_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should remove the column and return the deleted entity', async () => {
+      // Arrange
+      const column = mockColumn();
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+      mockColumnsRepository.remove.mockResolvedValue(column);
+
+      // Act
+      const result = await service.remove(COLUMN_ID, USER_ID);
+
+      // Assert
+      expect(mockColumnsRepository.remove).toHaveBeenCalledWith(column);
+      expect(result).toEqual(column);
+    });
+
+    it('should throw ForbiddenException when the column is not owned by the user', async () => {
+      // Arrange
+      const column = {
+        ...mockColumn(),
+        project: { id: PROJECT_ID, userId: OTHER_USER_ID },
+      };
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+
+      // Act & Assert
+      await expect(service.remove(COLUMN_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(mockColumnsRepository.remove).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the column does not exist', async () => {
+      // Arrange
+      mockColumnsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.remove(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,6 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ProjectsController } from '@/projects/projects.controller';
 import { ProjectsService } from '@/projects/projects.service';
+import { CreateProjectDto } from '@/projects/dto/create-project.dto';
+import { UpdateProjectDto } from '@/projects/dto/update-project.dto';
+import { Project } from '@/projects/entities/project.entity';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+
+const mockReq = { user: { userId: USER_ID, email: 'user@test.com' } };
+
+const mockProject = (): Project =>
+  ({
+    id: 1,
+    name: 'Alpha',
+    description: 'Test project',
+    userId: USER_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }) as Project;
+
+// ── Mock service ──────────────────────────────────────────────────────────────
+
+const mockProjectsService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('ProjectsController', () => {
   let controller: ProjectsController;
@@ -8,13 +40,147 @@ describe('ProjectsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProjectsController],
-      providers: [ProjectsService],
+      providers: [
+        {
+          provide: ProjectsService,
+          useValue: mockProjectsService,
+        },
+      ],
     }).compile();
 
     controller = module.get<ProjectsController>(ProjectsController);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should delegate to ProjectsService.create with dto and userId from JWT', async () => {
+      // Arrange
+      const dto: CreateProjectDto = { name: 'Alpha', description: 'Desc' };
+      const project = mockProject();
+      mockProjectsService.create.mockResolvedValue(project);
+
+      // Act
+      const result = await controller.create(dto, mockReq);
+
+      // Assert
+      expect(mockProjectsService.create).toHaveBeenCalledWith(dto, USER_ID);
+      expect(result).toEqual(project);
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should delegate to ProjectsService.findAll with userId from JWT', async () => {
+      // Arrange
+      const projects = [mockProject()];
+      mockProjectsService.findAll.mockResolvedValue(projects);
+
+      // Act
+      const result = await controller.findAll(mockReq);
+
+      // Assert
+      expect(mockProjectsService.findAll).toHaveBeenCalledWith(USER_ID);
+      expect(result).toEqual(projects);
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should delegate to ProjectsService.findOne with id and userId', async () => {
+      // Arrange
+      const project = mockProject();
+      mockProjectsService.findOne.mockResolvedValue(project);
+
+      // Act
+      const result = await controller.findOne(project.id, mockReq);
+
+      // Assert
+      expect(mockProjectsService.findOne).toHaveBeenCalledWith(
+        project.id,
+        USER_ID,
+      );
+      expect(result).toEqual(project);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      // Arrange
+      mockProjectsService.findOne.mockRejectedValue(
+        new NotFoundException(
+          'Project with ID "99" not found or you don\'t have access.',
+        ),
+      );
+
+      // Act & Assert
+      await expect(controller.findOne(99, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should delegate to ProjectsService.update with id, dto, and userId', async () => {
+      // Arrange
+      const dto: UpdateProjectDto = { name: 'Alpha v2' };
+      const updated = { ...mockProject(), name: 'Alpha v2' } as Project;
+      mockProjectsService.update.mockResolvedValue(updated);
+
+      // Act
+      const result = await controller.update(1, dto, mockReq);
+
+      // Assert
+      expect(mockProjectsService.update).toHaveBeenCalledWith(1, dto, USER_ID);
+      expect(result).toEqual(updated);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      // Arrange
+      mockProjectsService.update.mockRejectedValue(new NotFoundException());
+
+      // Act & Assert
+      await expect(controller.update(99, {}, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should delegate to ProjectsService.remove with id and userId', async () => {
+      // Arrange
+      const project = mockProject();
+      mockProjectsService.remove.mockResolvedValue(project);
+
+      // Act
+      const result = await controller.remove(project.id, mockReq);
+
+      // Assert
+      expect(mockProjectsService.remove).toHaveBeenCalledWith(
+        project.id,
+        USER_ID,
+      );
+      expect(result).toEqual(project);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      // Arrange
+      mockProjectsService.remove.mockRejectedValue(new NotFoundException());
+
+      // Act & Assert
+      await expect(controller.remove(99, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,18 +1,277 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
 import { ProjectsService } from '@/projects/projects.service';
+import { Project } from '@/projects/entities/project.entity';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
+import { CreateProjectDto } from '@/projects/dto/create-project.dto';
+import { UpdateProjectDto } from '@/projects/dto/update-project.dto';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+
+const mockProject = (): Project =>
+  ({
+    id: 1,
+    name: 'Alpha',
+    description: 'Test project',
+    userId: USER_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }) as Project;
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockTransactionalManager = {
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockProjectsRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  merge: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+  manager: {
+    transaction: jest.fn(),
+  },
+};
+
+const mockColumnsRepository = {}; // satisfies the DI token; no column repo methods are exercised
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('ProjectsService', () => {
   let service: ProjectsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ProjectsService],
+      providers: [
+        ProjectsService,
+        {
+          provide: getRepositoryToken(Project),
+          useValue: mockProjectsRepository,
+        },
+        {
+          provide: getRepositoryToken(BoardColumn),
+          useValue: mockColumnsRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<ProjectsService>(ProjectsService);
+
+    jest.clearAllMocks();
+
+    // Default: transaction calls the callback with the mock manager
+    mockProjectsRepository.manager.transaction.mockImplementation(
+      async (
+        cb: (manager: typeof mockTransactionalManager) => Promise<Project>,
+      ) => cb(mockTransactionalManager),
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create a project and seed three default board columns', async () => {
+      // Arrange
+      const dto: CreateProjectDto = { name: 'Alpha', description: 'Desc' };
+      const project = mockProject();
+
+      mockTransactionalManager.create
+        .mockReturnValueOnce(project) // first call → Project
+        .mockReturnValueOnce({ name: 'To Do', order: 0, projectId: project.id })
+        .mockReturnValueOnce({
+          name: 'In Progress',
+          order: 1,
+          projectId: project.id,
+        })
+        .mockReturnValueOnce({ name: 'Done', order: 2, projectId: project.id });
+      mockTransactionalManager.save
+        .mockResolvedValueOnce(project) // save project
+        .mockResolvedValueOnce([]); // save columns
+
+      // Act
+      const result = await service.create(dto, USER_ID);
+
+      // Assert
+      expect(mockProjectsRepository.manager.transaction).toHaveBeenCalled();
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(Project, {
+        ...dto,
+        userId: USER_ID,
+      });
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({
+          name: 'To Do',
+          order: 0,
+          projectId: project.id,
+        }),
+      );
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({
+          name: 'In Progress',
+          order: 1,
+          projectId: project.id,
+        }),
+      );
+      expect(mockTransactionalManager.create).toHaveBeenCalledWith(
+        BoardColumn,
+        expect.objectContaining({
+          name: 'Done',
+          order: 2,
+          projectId: project.id,
+        }),
+      );
+      expect(mockTransactionalManager.save).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(project);
+    });
+
+    it('should propagate errors thrown inside the transaction', async () => {
+      // Arrange
+      const dto: CreateProjectDto = { name: 'Alpha' };
+      mockProjectsRepository.manager.transaction.mockRejectedValue(
+        new Error('DB connection lost'),
+      );
+
+      // Act & Assert
+      await expect(service.create(dto, USER_ID)).rejects.toThrow(
+        'DB connection lost',
+      );
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should return all projects belonging to the user ordered by createdAt DESC', async () => {
+      // Arrange
+      const projects = [
+        mockProject(),
+        { ...mockProject(), id: 2, name: 'Beta' },
+      ];
+      mockProjectsRepository.find.mockResolvedValue(projects);
+
+      // Act
+      const result = await service.findAll(USER_ID);
+
+      // Assert
+      expect(mockProjectsRepository.find).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toEqual(projects);
+    });
+
+    it('should return an empty array when the user has no projects', async () => {
+      // Arrange
+      mockProjectsRepository.find.mockResolvedValue([]);
+
+      // Act
+      const result = await service.findAll(USER_ID);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should return the project when it exists and belongs to the user', async () => {
+      // Arrange
+      const project = mockProject();
+      mockProjectsRepository.findOne.mockResolvedValue(project);
+
+      // Act
+      const result = await service.findOne(project.id, USER_ID);
+
+      // Assert
+      expect(mockProjectsRepository.findOne).toHaveBeenCalledWith({
+        where: { id: project.id, userId: USER_ID },
+      });
+      expect(result).toEqual(project);
+    });
+
+    it('should throw NotFoundException when project does not exist or is owned by another user', async () => {
+      // Arrange
+      mockProjectsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findOne(99, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should merge and save the updated project', async () => {
+      // Arrange
+      const project = mockProject();
+      const dto: UpdateProjectDto = { name: 'Alpha v2' };
+      const updated = { ...project, name: 'Alpha v2' } as Project;
+
+      mockProjectsRepository.findOne.mockResolvedValue(project);
+      mockProjectsRepository.merge.mockReturnValue(updated);
+      mockProjectsRepository.save.mockResolvedValue(updated);
+
+      // Act
+      const result = await service.update(project.id, dto, USER_ID);
+
+      // Assert
+      expect(mockProjectsRepository.merge).toHaveBeenCalledWith(project, dto);
+      expect(mockProjectsRepository.save).toHaveBeenCalledWith(updated);
+      expect(result).toEqual(updated);
+    });
+
+    it('should throw NotFoundException when the project is not found', async () => {
+      // Arrange
+      mockProjectsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.update(99, { name: 'X' }, USER_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(mockProjectsRepository.merge).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should remove the project and return the deleted entity', async () => {
+      // Arrange
+      const project = mockProject();
+      mockProjectsRepository.findOne.mockResolvedValue(project);
+      mockProjectsRepository.remove.mockResolvedValue(project);
+
+      // Act
+      const result = await service.remove(project.id, USER_ID);
+
+      // Assert
+      expect(mockProjectsRepository.remove).toHaveBeenCalledWith(project);
+      expect(result).toEqual(project);
+    });
+
+    it('should throw NotFoundException when the project is not found', async () => {
+      // Arrange
+      mockProjectsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.remove(99, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(mockProjectsRepository.remove).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/backend/src/tasks/tasks.controller.spec.ts
+++ b/apps/backend/src/tasks/tasks.controller.spec.ts
@@ -1,6 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { TasksController } from '@/tasks/tasks.controller';
 import { TasksService } from '@/tasks/tasks.service';
+import { CreateTaskDto } from '@/tasks/dto/create-task.dto';
+import { UpdateTaskDto } from '@/tasks/dto/update-task.dto';
+import { Task } from '@/tasks/entities/task.entity';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+const COLUMN_ID = 20;
+const TASK_ID = 30;
+
+const mockReq = { user: { userId: USER_ID, email: 'user@test.com' } };
+
+const mockTask = (): Task =>
+  ({
+    id: TASK_ID,
+    title: 'Fix bug',
+    description: null,
+    order: 0,
+    columnId: COLUMN_ID,
+  }) as Task;
+
+// ── Mock service ──────────────────────────────────────────────────────────────
+
+const mockTasksService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('TasksController', () => {
   let controller: TasksController;
@@ -8,13 +41,181 @@ describe('TasksController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TasksController],
-      providers: [TasksService],
+      providers: [
+        {
+          provide: TasksService,
+          useValue: mockTasksService,
+        },
+      ],
     }).compile();
 
     controller = module.get<TasksController>(TasksController);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should delegate to TasksService.create with dto and userId', async () => {
+      // Arrange
+      const dto: CreateTaskDto = { title: 'Fix bug', columnId: COLUMN_ID };
+      const task = mockTask();
+      mockTasksService.create.mockResolvedValue(task);
+
+      // Act
+      const result = await controller.create(dto, mockReq);
+
+      // Assert
+      expect(mockTasksService.create).toHaveBeenCalledWith(dto, USER_ID);
+      expect(result).toEqual(task);
+    });
+
+    it('should propagate ForbiddenException from the service', async () => {
+      // Arrange
+      mockTasksService.create.mockRejectedValue(new ForbiddenException());
+
+      // Act & Assert
+      await expect(
+        controller.create({ title: 'X', columnId: 999 }, mockReq),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should delegate to TasksService.findAll with columnId and userId', async () => {
+      // Arrange
+      const tasks = [mockTask()];
+      mockTasksService.findAll.mockResolvedValue(tasks);
+
+      // Act
+      const result = await controller.findAll(COLUMN_ID, mockReq);
+
+      // Assert
+      expect(mockTasksService.findAll).toHaveBeenCalledWith(COLUMN_ID, USER_ID);
+      expect(result).toEqual(tasks);
+    });
+
+    it('should propagate ForbiddenException when the column is not owned by the user', async () => {
+      // Arrange
+      mockTasksService.findAll.mockRejectedValue(new ForbiddenException());
+
+      // Act & Assert
+      await expect(controller.findAll(999, mockReq)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should delegate to TasksService.findOne with id and userId', async () => {
+      // Arrange
+      const task = mockTask();
+      mockTasksService.findOne.mockResolvedValue(task);
+
+      // Act
+      const result = await controller.findOne(TASK_ID, mockReq);
+
+      // Assert
+      expect(mockTasksService.findOne).toHaveBeenCalledWith(TASK_ID, USER_ID);
+      expect(result).toEqual(task);
+    });
+
+    it('should propagate NotFoundException from the service', async () => {
+      // Arrange
+      mockTasksService.findOne.mockRejectedValue(new NotFoundException());
+
+      // Act & Assert
+      await expect(controller.findOne(999, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should delegate to TasksService.update with id, dto, and userId', async () => {
+      // Arrange
+      const dto: UpdateTaskDto = { title: 'Updated title' };
+      const updated = { ...mockTask(), title: 'Updated title' } as Task;
+      mockTasksService.update.mockResolvedValue(updated);
+
+      // Act
+      const result = await controller.update(TASK_ID, dto, mockReq);
+
+      // Assert
+      expect(mockTasksService.update).toHaveBeenCalledWith(
+        TASK_ID,
+        dto,
+        USER_ID,
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it('should propagate ForbiddenException when moving to a column the user does not own', async () => {
+      // Arrange
+      mockTasksService.update.mockRejectedValue(new ForbiddenException());
+
+      // Act & Assert
+      await expect(
+        controller.update(TASK_ID, { columnId: 999 }, mockReq),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should propagate NotFoundException when the task does not exist', async () => {
+      // Arrange
+      mockTasksService.update.mockRejectedValue(new NotFoundException());
+
+      // Act & Assert
+      await expect(controller.update(999, {}, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should delegate to TasksService.remove with id and userId', async () => {
+      // Arrange
+      const task = mockTask();
+      mockTasksService.remove.mockResolvedValue(task);
+
+      // Act
+      const result = await controller.remove(TASK_ID, mockReq);
+
+      // Assert
+      expect(mockTasksService.remove).toHaveBeenCalledWith(TASK_ID, USER_ID);
+      expect(result).toEqual(task);
+    });
+
+    it('should propagate ForbiddenException from the service', async () => {
+      // Arrange
+      mockTasksService.remove.mockRejectedValue(new ForbiddenException());
+
+      // Act & Assert
+      await expect(controller.remove(TASK_ID, mockReq)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('should propagate NotFoundException when the task does not exist', async () => {
+      // Arrange
+      mockTasksService.remove.mockRejectedValue(new NotFoundException());
+
+      // Act & Assert
+      await expect(controller.remove(999, mockReq)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -1,18 +1,546 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { TasksService } from '@/tasks/tasks.service';
+import { Task } from '@/tasks/entities/task.entity';
+import { BoardColumn } from '@/board-columns/entities/board-column.entity';
+import { CreateTaskDto } from '@/tasks/dto/create-task.dto';
+import { UpdateTaskDto } from '@/tasks/dto/update-task.dto';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USER_ID = 1;
+const OTHER_USER_ID = 99;
+const PROJECT_ID = 10;
+const COLUMN_ID = 20;
+const TARGET_COLUMN_ID = 21;
+const TASK_ID = 30;
+
+const mockProject = () => ({ id: PROJECT_ID, userId: USER_ID });
+
+const mockColumnWithProject = (userId = USER_ID) =>
+  ({
+    id: COLUMN_ID,
+    name: 'To Do',
+    order: 0,
+    projectId: PROJECT_ID,
+    project: { id: PROJECT_ID, userId },
+  }) as unknown as BoardColumn;
+
+const mockTask = (): Task =>
+  ({
+    id: TASK_ID,
+    title: 'Fix bug',
+    description: null,
+    order: 0,
+    columnId: COLUMN_ID,
+    column: mockColumnWithProject(),
+  }) as unknown as Task;
+
+// ── Helpers for query builder mocks ──────────────────────────────────────────
+
+const makeQB = (resolvedValue: unknown) => ({
+  innerJoinAndSelect: jest.fn().mockReturnThis(),
+  leftJoinAndSelect: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  setLock: jest.fn().mockReturnThis(),
+  getOne: jest.fn().mockResolvedValue(resolvedValue),
+});
+
+// ── Repository mocks ──────────────────────────────────────────────────────────
+
+const mockTasksRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  merge: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+  manager: {
+    transaction: jest.fn(),
+  },
+};
+
+const mockColumnsRepository = {
+  findOne: jest.fn(),
+  manager: {
+    transaction: jest.fn(),
+  },
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
 
 describe('TasksService', () => {
   let service: TasksService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TasksService],
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: mockTasksRepository,
+        },
+        {
+          provide: getRepositoryToken(BoardColumn),
+          useValue: mockColumnsRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<TasksService>(TasksService);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    const setupCreateTransaction = (
+      columnWithProject: unknown,
+      lastTask: unknown,
+      savedTask: Task,
+    ) => {
+      const mockManager = {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValue(makeQB(columnWithProject)),
+        findOne: jest.fn().mockResolvedValue(lastTask),
+        create: jest.fn().mockReturnValue(savedTask),
+        save: jest.fn().mockResolvedValue(savedTask),
+      };
+      // create() uses columnsRepository.manager.transaction, not tasksRepository
+      mockColumnsRepository.manager.transaction.mockImplementation(
+        async (cb: (m: typeof mockManager) => Promise<Task>) => cb(mockManager),
+      );
+      return mockManager;
+    };
+
+    it('should create a task with auto-assigned order 0 when the column is empty', async () => {
+      // Arrange
+      const dto: CreateTaskDto = { title: 'Fix bug', columnId: COLUMN_ID };
+      const task = mockTask();
+      const manager = setupCreateTransaction(
+        mockColumnWithProject(),
+        null,
+        task,
+      );
+
+      // Act
+      const result = await service.create(dto, USER_ID);
+
+      // Assert
+      expect(manager.create).toHaveBeenCalledWith(
+        Task,
+        expect.objectContaining({
+          title: 'Fix bug',
+          columnId: COLUMN_ID,
+          order: 0,
+        }),
+      );
+      expect(result).toEqual(task);
+    });
+
+    it('should auto-assign order as last task order + 1', async () => {
+      // Arrange
+      const dto: CreateTaskDto = { title: 'Second task', columnId: COLUMN_ID };
+      const task = { ...mockTask(), order: 3 } as Task;
+      const manager = setupCreateTransaction(
+        mockColumnWithProject(),
+        { order: 2 },
+        task,
+      );
+
+      // Act
+      await service.create(dto, USER_ID);
+
+      // Assert
+      expect(manager.create).toHaveBeenCalledWith(
+        Task,
+        expect.objectContaining({ order: 3 }),
+      );
+    });
+
+    it('should use the provided order when explicitly supplied', async () => {
+      // Arrange
+      const dto: CreateTaskDto = {
+        title: 'Pinned',
+        columnId: COLUMN_ID,
+        order: 5,
+      };
+      const task = { ...mockTask(), order: 5 } as Task;
+      const manager = setupCreateTransaction(
+        mockColumnWithProject(),
+        null,
+        task,
+      );
+
+      // Act
+      await service.create(dto, USER_ID);
+
+      // Assert
+      expect(manager.create).toHaveBeenCalledWith(
+        Task,
+        expect.objectContaining({ order: 5 }),
+      );
+    });
+
+    it('should throw NotFoundException when the column does not exist', async () => {
+      // Arrange
+      const dto: CreateTaskDto = { title: 'Fix bug', columnId: 999 };
+      setupCreateTransaction(null, null, mockTask());
+
+      // Act & Assert
+      await expect(service.create(dto, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when the column belongs to another user', async () => {
+      // Arrange
+      const dto: CreateTaskDto = { title: 'Fix bug', columnId: COLUMN_ID };
+      setupCreateTransaction(
+        mockColumnWithProject(OTHER_USER_ID),
+        null,
+        mockTask(),
+      );
+
+      // Act & Assert
+      await expect(service.create(dto, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should return tasks in the column ordered by order ASC', async () => {
+      // Arrange
+      const column = mockColumnWithProject();
+      const tasks = [mockTask()];
+      mockColumnsRepository.findOne.mockResolvedValue(column);
+      mockTasksRepository.find.mockResolvedValue(tasks);
+
+      // Act
+      const result = await service.findAll(COLUMN_ID, USER_ID);
+
+      // Assert
+      expect(mockTasksRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { columnId: COLUMN_ID },
+          order: { order: 'ASC' },
+        }),
+      );
+      expect(result).toEqual(tasks);
+    });
+
+    it('should throw NotFoundException when the column does not exist', async () => {
+      // Arrange
+      mockColumnsRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findAll(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when the column belongs to another user', async () => {
+      // Arrange
+      mockColumnsRepository.findOne.mockResolvedValue(
+        mockColumnWithProject(OTHER_USER_ID),
+      );
+
+      // Act & Assert
+      await expect(service.findAll(COLUMN_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should return the task when it exists and is owned by the user', async () => {
+      // Arrange
+      const task = mockTask();
+      mockTasksRepository.findOne.mockResolvedValue(task);
+
+      // Act
+      const result = await service.findOne(TASK_ID, USER_ID);
+
+      // Assert
+      expect(mockTasksRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: TASK_ID } }),
+      );
+      expect(result).toEqual(task);
+    });
+
+    it('should throw NotFoundException when the task does not exist', async () => {
+      // Arrange
+      mockTasksRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findOne(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when the task belongs to another user', async () => {
+      // Arrange
+      const task = {
+        ...mockTask(),
+        column: mockColumnWithProject(OTHER_USER_ID),
+      } as Task;
+      mockTasksRepository.findOne.mockResolvedValue(task);
+
+      // Act & Assert
+      await expect(service.findOne(TASK_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── update (same column) ─────────────────────────────────────────────────────
+
+  describe('update — same column', () => {
+    it('should merge and save when columnId is unchanged', async () => {
+      // Arrange
+      const task = mockTask();
+      const dto: UpdateTaskDto = { title: 'Updated title' };
+      const updated = { ...task, title: 'Updated title' } as Task;
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      mockTasksRepository.merge.mockReturnValue(updated);
+      mockTasksRepository.save.mockResolvedValue(updated);
+
+      // Act
+      const result = await service.update(TASK_ID, dto, USER_ID);
+
+      // Assert
+      expect(mockTasksRepository.merge).toHaveBeenCalledWith(task, dto);
+      expect(mockTasksRepository.save).toHaveBeenCalledWith(updated);
+      expect(result).toEqual(updated);
+    });
+
+    it('should throw NotFoundException when the task does not exist', async () => {
+      // Arrange
+      mockTasksRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.update(999, { title: 'X' }, USER_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when the task belongs to another user', async () => {
+      // Arrange
+      const task = {
+        ...mockTask(),
+        column: mockColumnWithProject(OTHER_USER_ID),
+      } as Task;
+      mockTasksRepository.findOne.mockResolvedValue(task);
+
+      // Act & Assert
+      await expect(
+        service.update(TASK_ID, { title: 'X' }, USER_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // ── update (cross-column move) ───────────────────────────────────────────────
+
+  describe('update — cross-column move', () => {
+    const setupMoveTransaction = (
+      lockedTask: unknown,
+      targetColumn: unknown,
+      lastTaskInTarget: unknown,
+      updatedTask: Task,
+    ) => {
+      const taskQB = makeQB(lockedTask);
+      const columnQB = makeQB(targetColumn);
+
+      const mockManager = {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(taskQB) // first call: lock the task
+          .mockReturnValueOnce(columnQB), // second call: lock the target column
+        findOne: jest.fn().mockResolvedValue(lastTaskInTarget),
+        getRepository: jest.fn().mockReturnValue({
+          merge: jest.fn().mockReturnValue(updatedTask),
+          save: jest.fn().mockResolvedValue(updatedTask),
+        }),
+      };
+
+      mockTasksRepository.manager.transaction.mockImplementation(
+        async (cb: (m: typeof mockManager) => Promise<Task>) => cb(mockManager),
+      );
+
+      return mockManager;
+    };
+
+    it('should move the task and auto-assign order in the target column', async () => {
+      // Arrange
+      const task = mockTask();
+      const lockedTask = {
+        ...task,
+        column: mockColumnWithProject(),
+      };
+      const targetColumn = {
+        id: TARGET_COLUMN_ID,
+        project: mockProject(),
+      };
+      const updatedTask = {
+        ...task,
+        columnId: TARGET_COLUMN_ID,
+        order: 0,
+      } as Task;
+      const dto: UpdateTaskDto = { columnId: TARGET_COLUMN_ID };
+
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      const manager = setupMoveTransaction(
+        lockedTask,
+        targetColumn,
+        null,
+        updatedTask,
+      );
+
+      // Act
+      const result = await service.update(TASK_ID, dto, USER_ID);
+
+      // Assert
+      expect(mockTasksRepository.manager.transaction).toHaveBeenCalled();
+      expect(manager.createQueryBuilder).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(updatedTask);
+    });
+
+    it('should assign order as last task order + 1 in the target column', async () => {
+      // Arrange
+      const task = mockTask();
+      const lockedTask = { ...task, column: mockColumnWithProject() };
+      const targetColumn = { id: TARGET_COLUMN_ID, project: mockProject() };
+      const lastTask = { order: 4 };
+      const updatedTask = {
+        ...task,
+        columnId: TARGET_COLUMN_ID,
+        order: 5,
+      } as Task;
+      const dto: UpdateTaskDto = { columnId: TARGET_COLUMN_ID };
+
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      const manager = setupMoveTransaction(
+        lockedTask,
+        targetColumn,
+        lastTask,
+        updatedTask,
+      );
+
+      // Act
+      const result = await service.update(TASK_ID, dto, USER_ID);
+
+      // Assert — verify the service passed the computed order to merge, not just the return value
+      const taskRepo = manager.getRepository.mock.results[0].value as {
+        merge: jest.Mock;
+        save: jest.Mock;
+      };
+      expect(taskRepo.merge).toHaveBeenCalledWith(
+        lockedTask,
+        expect.objectContaining({ columnId: TARGET_COLUMN_ID, order: 5 }),
+      );
+      expect(result.order).toBe(5);
+    });
+
+    it('should throw NotFoundException when the target column does not exist', async () => {
+      // Arrange
+      const task = mockTask();
+      const lockedTask = { ...task, column: mockColumnWithProject() };
+      const dto: UpdateTaskDto = { columnId: TARGET_COLUMN_ID };
+
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      setupMoveTransaction(lockedTask, null, null, task);
+
+      // Act & Assert
+      await expect(
+        service.update(TASK_ID, dto, USER_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when the target column belongs to another user', async () => {
+      // Arrange
+      const task = mockTask();
+      const lockedTask = { ...task, column: mockColumnWithProject() };
+      const targetColumn = {
+        id: TARGET_COLUMN_ID,
+        project: { id: PROJECT_ID, userId: OTHER_USER_ID },
+      };
+      const dto: UpdateTaskDto = { columnId: TARGET_COLUMN_ID };
+
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      setupMoveTransaction(lockedTask, targetColumn, null, task);
+
+      // Act & Assert
+      await expect(
+        service.update(TASK_ID, dto, USER_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when the task disappears inside the transaction', async () => {
+      // Arrange — simulates the task being deleted between the outer findOne and the lock
+      const task = mockTask();
+      const dto: UpdateTaskDto = { columnId: TARGET_COLUMN_ID };
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      setupMoveTransaction(null, mockColumnWithProject(), null, task);
+
+      // Act & Assert
+      await expect(
+        service.update(TASK_ID, dto, USER_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should remove the task and return the deleted entity', async () => {
+      // Arrange
+      const task = mockTask();
+      mockTasksRepository.findOne.mockResolvedValue(task);
+      mockTasksRepository.remove.mockResolvedValue(task);
+
+      // Act
+      const result = await service.remove(TASK_ID, USER_ID);
+
+      // Assert
+      expect(mockTasksRepository.remove).toHaveBeenCalledWith(task);
+      expect(result).toEqual(task);
+    });
+
+    it('should throw NotFoundException when the task does not exist', async () => {
+      // Arrange
+      mockTasksRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.remove(999, USER_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(mockTasksRepository.remove).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when the task belongs to another user', async () => {
+      // Arrange
+      const task = {
+        ...mockTask(),
+        column: mockColumnWithProject(OTHER_USER_ID),
+      } as Task;
+      mockTasksRepository.findOne.mockResolvedValue(task);
+
+      // Act & Assert
+      await expect(service.remove(TASK_ID, USER_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(mockTasksRepository.remove).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -13,9 +13,9 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "rootDir": "../../",
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@shared/validation/*": ["../../libs/shared-validation/src/*"],
       "@shared/dtos/*": ["../../libs/shared-dtos/src/*"]
     },
@@ -29,5 +29,5 @@
     "noFallthroughCasesInSwitch": false,
     "useUnknownInCatchVariables": true
   },
-  "include": ["src/**/*", "test/**/*", "../../libs/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/apps/frontend/src/app/auth/components/login/login.spec.ts
+++ b/apps/frontend/src/app/auth/components/login/login.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { Login } from '@/app/auth/components/login/login';
 import { Auth } from '@/app/auth/services/auth';
 import { of, throwError } from 'rxjs';
@@ -15,6 +16,7 @@ describe('Login', () => {
     await TestBed.configureTestingModule({
       imports: [Login],
       providers: [
+        provideRouter([]),
         {
           provide: Auth,
           useValue: authServiceSpyObj,

--- a/apps/frontend/src/app/auth/components/register/register.spec.ts
+++ b/apps/frontend/src/app/auth/components/register/register.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { Register } from '@/app/auth/components/register/register';
 import { Auth } from '@/app/auth/services/auth';
 import { of, throwError } from 'rxjs';
@@ -15,6 +16,7 @@ describe('Register', () => {
     await TestBed.configureTestingModule({
       imports: [Register],
       providers: [
+        provideRouter([]),
         {
           provide: Auth,
           useValue: authServiceSpyObj,

--- a/apps/frontend/src/app/auth/guards/auth-guard.spec.ts
+++ b/apps/frontend/src/app/auth/guards/auth-guard.spec.ts
@@ -1,17 +1,42 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
-
-import { authGuard } from './auth-guard';
+import { CanActivateFn, Router } from '@angular/router';
+import { authGuard } from '@/app/auth/guards/auth-guard';
+import { Auth } from '@/app/auth/services/auth';
 
 describe('authGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) =>
-    TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+  let authServiceSpy: jasmine.SpyObj<Auth>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  const executeGuard: CanActivateFn = (...args) =>
+    TestBed.runInInjectionContext(() => authGuard(...args));
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authServiceSpy = jasmine.createSpyObj<Auth>('Auth', ['isAuthenticated']);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Auth, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
   });
 
   it('should be created', () => {
     expect(executeGuard).toBeTruthy();
+  });
+
+  it('should return true when the user is authenticated', () => {
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    const result = executeGuard({} as never, {} as never);
+    expect(result).toBeTrue();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should return false and redirect to /auth/login when the user is not authenticated', () => {
+    authServiceSpy.isAuthenticated.and.returnValue(false);
+    const result = executeGuard({} as never, {} as never);
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/auth/login']);
   });
 });

--- a/apps/frontend/src/app/auth/interceptors/token-interceptor.spec.ts
+++ b/apps/frontend/src/app/auth/interceptors/token-interceptor.spec.ts
@@ -1,17 +1,52 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpInterceptorFn } from '@angular/common/http';
-
-import { tokenInterceptor } from './token-interceptor';
+import { provideHttpClient, withInterceptors, HttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { tokenInterceptor } from '@/app/auth/interceptors/token-interceptor';
+import { Auth } from '@/app/auth/services/auth';
 
 describe('tokenInterceptor', () => {
-  const interceptor: HttpInterceptorFn = (req, next) => 
-    TestBed.runInInjectionContext(() => tokenInterceptor(req, next));
+  let httpMock: HttpTestingController;
+  let http: HttpClient;
+  let authServiceSpy: jasmine.SpyObj<Auth>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authServiceSpy = jasmine.createSpyObj<Auth>('Auth', ['getToken']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([tokenInterceptor])),
+        provideHttpClientTesting(),
+        { provide: Auth, useValue: authServiceSpy },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
+  afterEach(() => httpMock.verify());
+
   it('should be created', () => {
-    expect(interceptor).toBeTruthy();
+    expect(tokenInterceptor).toBeTruthy();
+  });
+
+  it('should attach Authorization: Bearer header when a token is present', () => {
+    authServiceSpy.getToken.and.returnValue('my_jwt_token');
+
+    http.get('/api/test').subscribe();
+
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer my_jwt_token');
+    req.flush({});
+  });
+
+  it('should forward the request unchanged when no token is present', () => {
+    authServiceSpy.getToken.and.returnValue(null);
+
+    http.get('/api/test').subscribe();
+
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
   });
 });

--- a/apps/frontend/src/app/auth/services/auth.spec.ts
+++ b/apps/frontend/src/app/auth/services/auth.spec.ts
@@ -1,82 +1,158 @@
 import { TestBed } from '@angular/core/testing';
-import { Auth } from '@/app/auth/services/auth';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Auth } from '@/app/auth/services/auth';
 import { RegisterUserDto } from '@shared/dtos/auth/register-user.dto';
 import { UserResponseDto } from '@shared/dtos/user/user-response.dto';
 import { LoginUserDto } from '@shared/dtos/auth/login-user.dto';
 import { AccessTokenDto } from '@shared/dtos/auth/access-token.dto';
+import { environment } from '@/environments/environment';
+
+const API_URL = `${environment.apiUrl}/auth`;
+const TOKEN_KEY = 'access_token';
+
+// Build a minimal valid JWT with the given payload (not cryptographically signed).
+// btoa is available globally in Node.js 18+ and all browsers; requires Node 18+ in Jest.
+function makeJwt(payload: object): string {
+  const encoded = btoa(JSON.stringify(payload));
+  return `header.${encoded}.signature`;
+}
 
 describe('Auth', () => {
   let service: Auth;
   let httpMock: HttpTestingController;
 
-  const apiUrl = 'http://localhost:3000/auth';
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideHttpClient(), provideHttpClientTesting()],
     });
-
     service = TestBed.inject(Auth);
     httpMock = TestBed.inject(HttpTestingController);
+    localStorage.clear();
   });
 
   afterEach(() => {
     httpMock.verify();
+    localStorage.clear();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
+  // ── register ─────────────────────────────────────────────────────────────────
+
   describe('register', () => {
     it('should POST to /register and return user data', () => {
-      const mockRegisterData: RegisterUserDto = {
-        name: 'Test',
-        email: 'email@test.com',
-        password: 'TestPassword@123',
-      };
+      const dto: RegisterUserDto = { name: 'Test', email: 'email@test.com', password: 'TestPassword@123' };
+      const response: UserResponseDto = { id: 1, name: 'Test', email: 'email@test.com', access_token: 'tok' };
 
-      const mockResponse: UserResponseDto = {
-        id: 1,
-        name: 'Test',
-        email: 'email@test.com',
-        access_token: 'access_token',
-      };
+      service.register(dto).subscribe(res => expect(res).toEqual(response));
 
-      service.register(mockRegisterData).subscribe((response) => {
-        expect(response).toEqual(mockResponse);
-      });
-
-      const req = httpMock.expectOne(`${apiUrl}/register`);
+      const req = httpMock.expectOne(`${API_URL}/register`);
       expect(req.request.method).toBe('POST');
-      expect(req.request.body).toEqual(mockRegisterData);
+      expect(req.request.body).toEqual(dto);
+      req.flush(response);
+    });
 
-      req.flush(mockResponse);
+    it('should store the access token in localStorage after registration', () => {
+      const dto: RegisterUserDto = { name: 'Test', email: 'email@test.com', password: 'TestPassword@123' };
+      const response: UserResponseDto = { id: 1, name: 'Test', email: 'email@test.com', access_token: 'stored_token' };
+
+      service.register(dto).subscribe();
+      httpMock.expectOne(`${API_URL}/register`).flush(response);
+
+      expect(localStorage.getItem(TOKEN_KEY)).toBe('stored_token');
     });
   });
 
+  // ── login ─────────────────────────────────────────────────────────────────────
+
   describe('login', () => {
-    it('should POST to /login and return acces token', () => {
-      const mockLoginData: LoginUserDto = {
-        email: 'email@test.com',
-        password: 'TestPassword@123',
-      };
+    it('should POST to /login and return the access token', () => {
+      const dto: LoginUserDto = { email: 'email@test.com', password: 'TestPassword@123' };
+      const response: AccessTokenDto = { access_token: 'tok' };
 
-      const mockResponse: AccessTokenDto = {
-        access_token: 'access_token',
-      };
+      service.login(dto).subscribe(res => expect(res).toEqual(response));
 
-      service.login(mockLoginData).subscribe((response) => {
-        expect(response).toEqual(mockResponse);
-      });
-
-      const req = httpMock.expectOne(`${apiUrl}/login`);
+      const req = httpMock.expectOne(`${API_URL}/login`);
       expect(req.request.method).toBe('POST');
-      expect(req.request.body).toEqual(mockLoginData);
+      expect(req.request.body).toEqual(dto);
+      req.flush(response);
+    });
 
-      req.flush(mockResponse);
+    it('should store the access token in localStorage after login', () => {
+      const dto: LoginUserDto = { email: 'email@test.com', password: 'TestPassword@123' };
+      const response: AccessTokenDto = { access_token: 'login_token' };
+
+      service.login(dto).subscribe();
+      httpMock.expectOne(`${API_URL}/login`).flush(response);
+
+      expect(localStorage.getItem(TOKEN_KEY)).toBe('login_token');
+    });
+  });
+
+  // ── logout ────────────────────────────────────────────────────────────────────
+
+  describe('logout', () => {
+    it('should remove the access token from localStorage', () => {
+      localStorage.setItem(TOKEN_KEY, 'some_token');
+      service.logout();
+      expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    });
+  });
+
+  // ── isAuthenticated ───────────────────────────────────────────────────────────
+
+  describe('isAuthenticated', () => {
+    it('should return true when a token exists in localStorage', () => {
+      localStorage.setItem(TOKEN_KEY, 'some_token');
+      expect(service.isAuthenticated()).toBeTrue();
+    });
+
+    it('should return false when no token exists in localStorage', () => {
+      localStorage.removeItem(TOKEN_KEY);
+      expect(service.isAuthenticated()).toBeFalse();
+    });
+  });
+
+  // ── getToken ──────────────────────────────────────────────────────────────────
+
+  describe('getToken', () => {
+    it('should return the stored token', () => {
+      localStorage.setItem(TOKEN_KEY, 'my_token');
+      expect(service.getToken()).toBe('my_token');
+    });
+
+    it('should return null when no token is stored', () => {
+      localStorage.removeItem(TOKEN_KEY);
+      expect(service.getToken()).toBeNull();
+    });
+  });
+
+  // ── getUserEmail ──────────────────────────────────────────────────────────────
+
+  describe('getUserEmail', () => {
+    it('should decode and return the email from a valid JWT payload', () => {
+      const token = makeJwt({ sub: 1, email: 'user@test.com' });
+      localStorage.setItem(TOKEN_KEY, token);
+      expect(service.getUserEmail()).toBe('user@test.com');
+    });
+
+    it('should return null when no token is stored', () => {
+      localStorage.removeItem(TOKEN_KEY);
+      expect(service.getUserEmail()).toBeNull();
+    });
+
+    it('should return null when the token payload is malformed', () => {
+      localStorage.setItem(TOKEN_KEY, 'bad.token.here');
+      expect(service.getUserEmail()).toBeNull();
+    });
+
+    it('should return null when the payload has no email field', () => {
+      const token = makeJwt({ sub: 1 });
+      localStorage.setItem(TOKEN_KEY, token);
+      expect(service.getUserEmail()).toBeNull();
     });
   });
 });

--- a/apps/frontend/src/app/pages/dashboard/dashboard.spec.ts
+++ b/apps/frontend/src/app/pages/dashboard/dashboard.spec.ts
@@ -1,27 +1,211 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { Dashboard } from '@/app/pages/dashboard/dashboard';
+import { ProjectService } from '@/app/projects/project.service';
+import { Auth } from '@/app/auth/services/auth';
+import { Project } from '@/app/projects/project.model';
 
-import { Dashboard } from './dashboard';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+// ── Stub child components ──────────────────────────────────────────────────────
+
+@Component({ selector: 'app-nav', template: '', standalone: true })
+class NavStub {}
+
+@Component({ selector: 'app-project-form', template: '', standalone: true })
+class ProjectFormStub {
+  @Input() project?: unknown;
+  @Output() saved = new EventEmitter<unknown>();
+  @Output() cancelled = new EventEmitter<void>();
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const mockProject = (id = 1): Project => ({
+  id,
+  name: `Project ${id}`,
+  description: 'Desc',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
 
 describe('Dashboard', () => {
   let component: Dashboard;
   let fixture: ComponentFixture<Dashboard>;
-  let httpMock: HttpTestingController;
+  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let authServiceSpy: jasmine.SpyObj<Auth>;
 
   beforeEach(async () => {
+    projectServiceSpy = jasmine.createSpyObj<ProjectService>('ProjectService', [
+      'getProjects',
+      'deleteProject',
+    ]);
+    projectServiceSpy.getProjects.and.returnValue(of([]));
+
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    authServiceSpy = jasmine.createSpyObj<Auth>('Auth', ['getUserEmail']);
+    authServiceSpy.getUserEmail.and.returnValue('user@test.com');
+
     await TestBed.configureTestingModule({
       imports: [Dashboard],
-      providers: [provideHttpClientTesting()],
-    }).compileComponents();
+      providers: [
+        { provide: ProjectService, useValue: projectServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: Auth, useValue: authServiceSpy },
+      ],
+    })
+      .overrideComponent(Dashboard, { set: { imports: [NavStub, ProjectFormStub] } })
+      .compileComponents();
 
     fixture = TestBed.createComponent(Dashboard);
     component = fixture.componentInstance;
-    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    httpMock.expectOne('/auth/profile').flush({ id: 1, name: 'Test', email: 'test@test.com' });
     expect(component).toBeTruthy();
+  });
+
+  // ── loadProjects ─────────────────────────────────────────────────────────────
+
+  describe('loadProjects', () => {
+    it('should populate projects and set loading to false on success', () => {
+      const projects = [mockProject(1), mockProject(2)];
+      projectServiceSpy.getProjects.and.returnValue(of(projects));
+
+      component.loadProjects();
+
+      expect(component.projects).toEqual(projects);
+      expect(component.loading).toBeFalse();
+    });
+
+    it('should set loading to false on error', () => {
+      projectServiceSpy.getProjects.and.returnValue(throwError(() => new Error('fail')));
+
+      component.loadProjects();
+
+      expect(component.loading).toBeFalse();
+      expect(component.projects).toEqual([]);
+    });
+  });
+
+  // ── openCreateModal ──────────────────────────────────────────────────────────
+
+  describe('openCreateModal', () => {
+    it('should set showModal to true and clear editingProject', () => {
+      component.editingProject = mockProject();
+      component.openCreateModal();
+      expect(component.showModal).toBeTrue();
+      expect(component.editingProject).toBeNull();
+    });
+  });
+
+  // ── openEditModal ────────────────────────────────────────────────────────────
+
+  describe('openEditModal', () => {
+    it('should set editingProject and showModal, stopping event propagation', () => {
+      const project = mockProject();
+      const event = new MouseEvent('click');
+      spyOn(event, 'stopPropagation');
+
+      component.openEditModal(project, event);
+
+      expect(event.stopPropagation).toHaveBeenCalled();
+      expect(component.editingProject).toEqual(project);
+      expect(component.showModal).toBeTrue();
+    });
+  });
+
+  // ── closeModal ───────────────────────────────────────────────────────────────
+
+  describe('closeModal', () => {
+    it('should set showModal to false and clear editingProject', () => {
+      component.showModal = true;
+      component.editingProject = mockProject();
+
+      component.closeModal();
+
+      expect(component.showModal).toBeFalse();
+      expect(component.editingProject).toBeNull();
+    });
+  });
+
+  // ── onProjectSaved ───────────────────────────────────────────────────────────
+
+  describe('onProjectSaved', () => {
+    it('should append the new project to the list in create mode', () => {
+      component.projects = [mockProject(1)];
+      component.editingProject = null;
+
+      component.onProjectSaved(mockProject(2));
+
+      expect(component.projects.length).toBe(2);
+      expect(component.projects[1].id).toBe(2);
+      expect(component.showModal).toBeFalse();
+    });
+
+    it('should replace the updated project in the list in edit mode', () => {
+      const original = mockProject(1);
+      const updated = { ...original, name: 'Alpha v2' };
+      component.projects = [original, mockProject(2)];
+      component.editingProject = original;
+
+      component.onProjectSaved(updated);
+
+      expect(component.projects[0].name).toBe('Alpha v2');
+      expect(component.projects.length).toBe(2);
+      expect(component.showModal).toBeFalse();
+    });
+  });
+
+  // ── deleteProject ────────────────────────────────────────────────────────────
+
+  describe('deleteProject', () => {
+    it('should remove the project from the list after successful deletion', () => {
+      const project = mockProject(1);
+      component.projects = [project, mockProject(2)];
+      projectServiceSpy.deleteProject.and.returnValue(of(undefined));
+      spyOn(window, 'confirm').and.returnValue(true);
+
+      component.deleteProject(project, new MouseEvent('click'));
+
+      expect(projectServiceSpy.deleteProject).toHaveBeenCalledWith(1);
+      expect(component.projects.length).toBe(1);
+      expect(component.projects[0].id).toBe(2);
+    });
+
+    it('should not call the service when the user cancels the confirmation dialog', () => {
+      const project = mockProject(1);
+      component.projects = [project];
+      spyOn(window, 'confirm').and.returnValue(false);
+
+      component.deleteProject(project, new MouseEvent('click'));
+
+      expect(projectServiceSpy.deleteProject).not.toHaveBeenCalled();
+      expect(component.projects.length).toBe(1);
+    });
+
+    it('should show an alert when deletion fails', () => {
+      const project = mockProject(1);
+      component.projects = [project];
+      projectServiceSpy.deleteProject.and.returnValue(throwError(() => new Error('fail')));
+      spyOn(window, 'confirm').and.returnValue(true);
+      spyOn(window, 'alert');
+
+      component.deleteProject(project, new MouseEvent('click'));
+
+      expect(window.alert).toHaveBeenCalled();
+      expect(component.projects.length).toBe(1);
+    });
+  });
+
+  // ── navigateToProject ────────────────────────────────────────────────────────
+
+  describe('navigateToProject', () => {
+    it('should navigate to /projects/:id', () => {
+      component.navigateToProject(mockProject(5));
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/projects', 5]);
+    });
   });
 });

--- a/apps/frontend/src/app/pages/kanban/kanban.spec.ts
+++ b/apps/frontend/src/app/pages/kanban/kanban.spec.ts
@@ -1,0 +1,476 @@
+import { Component, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { Kanban } from '@/app/pages/kanban/kanban';
+import { BoardColumnService } from '@/app/projects/board-column.service';
+import { TaskService } from '@/app/projects/task.service';
+import { ProjectService } from '@/app/projects/project.service';
+import { Auth } from '@/app/auth/services/auth';
+import { BoardColumn } from '@/app/projects/board-column.model';
+import { Task } from '@/app/projects/task.model';
+import { Project } from '@/app/projects/project.model';
+
+// ── Stub Nav (avoids Auth + Router deps in the child) ─────────────────────────
+
+@Component({ selector: 'app-nav', template: '', standalone: true })
+class NavStub {
+  @Input() title!: string;
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const mockTask = (id = 1, columnId = 10): Task => ({
+  id, title: `Task ${id}`, description: null, order: 0, columnId,
+  createdAt: '', updatedAt: '',
+});
+
+const mockColumn = (id = 10, tasks: Task[] = []): BoardColumn => ({
+  id, name: `Column ${id}`, order: 0, projectId: 1, tasks,
+  createdAt: '', updatedAt: '',
+});
+
+const mockProject = (): Project => ({
+  id: 1, name: 'Alpha', description: null, createdAt: '', updatedAt: '',
+});
+
+const makeDropEvent = (
+  prevData: Task[], prevIdx: number,
+  currData: Task[], currIdx: number,
+  currId: string,
+  sameContainer = false,
+): CdkDragDrop<Task[]> => {
+  const prev = { data: prevData, id: '10' };
+  const curr = sameContainer ? prev : { data: currData, id: currId };
+  return { previousContainer: prev, container: curr, previousIndex: prevIdx, currentIndex: currIdx } as unknown as CdkDragDrop<Task[]>;
+};
+
+describe('Kanban', () => {
+  let component: Kanban;
+  let fixture: ComponentFixture<Kanban>;
+  let boardColumnServiceSpy: jasmine.SpyObj<BoardColumnService>;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
+  let authServiceSpy: jasmine.SpyObj<Auth>;
+
+  beforeEach(async () => {
+    boardColumnServiceSpy = jasmine.createSpyObj<BoardColumnService>('BoardColumnService', [
+      'getColumns', 'createColumn', 'updateColumn', 'deleteColumn',
+    ]);
+    taskServiceSpy = jasmine.createSpyObj<TaskService>('TaskService', [
+      'createTask', 'updateTask', 'deleteTask',
+    ]);
+    projectServiceSpy = jasmine.createSpyObj<ProjectService>('ProjectService', ['getProject']);
+    authServiceSpy = jasmine.createSpyObj<Auth>('Auth', ['getUserEmail']);
+
+    boardColumnServiceSpy.getColumns.and.returnValue(of([]));
+    projectServiceSpy.getProject.and.returnValue(of(mockProject()));
+    authServiceSpy.getUserEmail.and.returnValue('user@test.com');
+
+    await TestBed.configureTestingModule({
+      imports: [Kanban],
+      providers: [
+        { provide: BoardColumnService, useValue: boardColumnServiceSpy },
+        { provide: TaskService, useValue: taskServiceSpy },
+        { provide: ProjectService, useValue: projectServiceSpy },
+        { provide: Auth, useValue: authServiceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
+      ],
+    })
+      .overrideComponent(Kanban, {
+        set: { imports: [NavStub] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(Kanban);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // ── ngOnInit ─────────────────────────────────────────────────────────────────
+
+  describe('ngOnInit', () => {
+    it('should parse projectId from the route and load board + project name', () => {
+      expect(component.projectId).toBe(1);
+      expect(component.projectName).toBe('Alpha');
+      expect(boardColumnServiceSpy.getColumns).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ── loadBoard ────────────────────────────────────────────────────────────────
+
+  describe('loadBoard', () => {
+    it('should set columns and clear loading flag on success', () => {
+      const columns = [mockColumn(10), mockColumn(11)];
+      boardColumnServiceSpy.getColumns.and.returnValue(of(columns));
+
+      component.loadBoard();
+
+      expect(component.columns).toEqual(columns);
+      expect(component.loading).toBeFalse();
+    });
+
+    it('should clear loading flag on error', () => {
+      boardColumnServiceSpy.getColumns.and.returnValue(throwError(() => new Error('fail')));
+
+      component.loadBoard();
+
+      expect(component.loading).toBeFalse();
+    });
+  });
+
+  // ── Escape key ───────────────────────────────────────────────────────────────
+
+  describe('onEscape', () => {
+    it('should cancel the task edit when a task is being edited', () => {
+      component.editingTask = mockTask();
+      component.onEscape();
+      expect(component.editingTask).toBeNull();
+    });
+
+    it('should do nothing when no task is being edited', () => {
+      component.editingTask = null;
+      expect(() => component.onEscape()).not.toThrow();
+    });
+  });
+
+  // ── Drag & Drop ───────────────────────────────────────────────────────────────
+
+  describe('onTaskDrop', () => {
+    it('should reorder tasks within the same column on success', () => {
+      const t1 = mockTask(1, 10);
+      const t2 = mockTask(2, 10);
+      const col = { ...mockColumn(10), tasks: [t1, t2] };
+      component.columns = [col];
+      taskServiceSpy.updateTask.and.returnValue(of({ ...t1, order: 1 }));
+
+      component.onTaskDrop(makeDropEvent(col.tasks, 0, col.tasks, 1, '10', true));
+
+      expect(taskServiceSpy.updateTask).toHaveBeenCalledWith(t1.id, { columnId: 10, order: 1 });
+      expect(col.tasks[0].id).toBe(t2.id);
+      expect(col.tasks[1].id).toBe(t1.id);
+    });
+
+    it('should revert the same-column reorder when the API call fails', () => {
+      const t1 = mockTask(1, 10);
+      const t2 = mockTask(2, 10);
+      const col = { ...mockColumn(10), tasks: [t1, t2] };
+      component.columns = [col];
+      taskServiceSpy.updateTask.and.returnValue(throwError(() => new Error('fail')));
+
+      component.onTaskDrop(makeDropEvent(col.tasks, 0, col.tasks, 1, '10', true));
+
+      expect(col.tasks[0].id).toBe(t1.id);
+      expect(col.tasks[1].id).toBe(t2.id);
+    });
+
+    it('should move a task to a different column on success', () => {
+      const task = mockTask(1, 10);
+      const src = { ...mockColumn(10), tasks: [task] };
+      const dst = { ...mockColumn(11), tasks: [] as Task[] };
+      component.columns = [src, dst];
+      taskServiceSpy.updateTask.and.returnValue(of({ ...task, columnId: 11, order: 0 }));
+
+      component.onTaskDrop(makeDropEvent(src.tasks, 0, dst.tasks, 0, '11'));
+
+      expect(taskServiceSpy.updateTask).toHaveBeenCalledWith(task.id, { columnId: 11, order: 0 });
+      expect(src.tasks.length).toBe(0);
+      expect(dst.tasks.length).toBe(1);
+      expect(dst.tasks[0].id).toBe(task.id);
+    });
+
+    it('should revert the cross-column move when the API call fails', () => {
+      const task = mockTask(1, 10);
+      const src = { ...mockColumn(10), tasks: [task] };
+      const dst = { ...mockColumn(11), tasks: [] as Task[] };
+      component.columns = [src, dst];
+      taskServiceSpy.updateTask.and.returnValue(throwError(() => new Error('fail')));
+
+      component.onTaskDrop(makeDropEvent(src.tasks, 0, dst.tasks, 0, '11'));
+
+      expect(src.tasks.length).toBe(1);
+      expect(src.tasks[0].id).toBe(task.id);
+      expect(dst.tasks.length).toBe(0);
+    });
+  });
+
+  // ── Column management ────────────────────────────────────────────────────────
+
+  describe('startAddColumn', () => {
+    it('should set addingColumn to true and clear newColumnName', () => {
+      component.newColumnName = 'leftover';
+      component.startAddColumn();
+      expect(component.addingColumn).toBeTrue();
+      expect(component.newColumnName).toBe('');
+    });
+  });
+
+  describe('confirmAddColumn', () => {
+    it('should close the input without calling the service when name is empty', () => {
+      component.newColumnName = '   ';
+      component.addingColumn = true;
+      component.confirmAddColumn();
+      expect(boardColumnServiceSpy.createColumn).not.toHaveBeenCalled();
+      expect(component.addingColumn).toBeFalse();
+    });
+
+    it('should call createColumn, append the new column, and reset state', () => {
+      const col = mockColumn(99);
+      boardColumnServiceSpy.createColumn.and.returnValue(of(col));
+      component.columns = [];
+      component.newColumnName = 'Backlog';
+      component.projectId = 1;
+
+      component.confirmAddColumn();
+
+      expect(boardColumnServiceSpy.createColumn).toHaveBeenCalledWith({ name: 'Backlog', projectId: 1 });
+      expect(component.columns.length).toBe(1);
+      expect(component.columns[0].id).toBe(99);
+      expect(component.addingColumn).toBeFalse();
+    });
+
+    it('should alert on error', () => {
+      boardColumnServiceSpy.createColumn.and.returnValue(throwError(() => new Error()));
+      spyOn(window, 'alert');
+      component.newColumnName = 'Backlog';
+      component.confirmAddColumn();
+      expect(window.alert).toHaveBeenCalled();
+    });
+  });
+
+  describe('startRenameColumn', () => {
+    it('should set editingColumnId and editingColumnName', () => {
+      const col = mockColumn(10);
+      component.startRenameColumn(col);
+      expect(component.editingColumnId).toBe(10);
+      expect(component.editingColumnName).toBe('Column 10');
+    });
+  });
+
+  describe('confirmRenameColumn', () => {
+    it('should cancel when name is empty', () => {
+      const col = mockColumn(10);
+      component.editingColumnName = '  ';
+      component.confirmRenameColumn(col);
+      expect(boardColumnServiceSpy.updateColumn).not.toHaveBeenCalled();
+      expect(component.editingColumnId).toBeNull();
+    });
+
+    it('should cancel when name is unchanged', () => {
+      const col = mockColumn(10);
+      component.editingColumnName = col.name;
+      component.confirmRenameColumn(col);
+      expect(boardColumnServiceSpy.updateColumn).not.toHaveBeenCalled();
+    });
+
+    it('should call updateColumn and update the column in the list', () => {
+      const col = mockColumn(10);
+      const updated = { ...col, name: 'In Review' };
+      boardColumnServiceSpy.updateColumn.and.returnValue(of(updated));
+      component.columns = [col];
+      component.editingColumnName = 'In Review';
+
+      component.confirmRenameColumn(col);
+
+      expect(boardColumnServiceSpy.updateColumn).toHaveBeenCalledWith(10, { name: 'In Review' });
+      expect(component.columns[0].name).toBe('In Review');
+      expect(component.editingColumnId).toBeNull();
+    });
+
+    it('should alert and keep the column name unchanged on error', () => {
+      const col = mockColumn(10);
+      boardColumnServiceSpy.updateColumn.and.returnValue(throwError(() => new Error()));
+      spyOn(window, 'alert');
+      component.columns = [col];
+      component.editingColumnName = 'New Name';
+
+      component.confirmRenameColumn(col);
+
+      expect(window.alert).toHaveBeenCalled();
+      expect(component.columns[0].name).toBe('Column 10');
+      expect(component.editingColumnId).toBeNull();
+    });
+  });
+
+  describe('cancelRenameColumn', () => {
+    it('should clear editingColumnId', () => {
+      component.editingColumnId = 10;
+      component.cancelRenameColumn();
+      expect(component.editingColumnId).toBeNull();
+    });
+  });
+
+  describe('deleteColumn', () => {
+    it('should call deleteColumn and remove the column from the list', () => {
+      const col = mockColumn(10);
+      component.columns = [col, mockColumn(11)];
+      boardColumnServiceSpy.deleteColumn.and.returnValue(of(undefined));
+      spyOn(window, 'confirm').and.returnValue(true);
+
+      component.deleteColumn(col);
+
+      expect(boardColumnServiceSpy.deleteColumn).toHaveBeenCalledWith(10);
+      expect(component.columns.length).toBe(1);
+      expect(component.columns[0].id).toBe(11);
+    });
+
+    it('should not call the service when confirm is cancelled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      component.deleteColumn(mockColumn(10));
+      expect(boardColumnServiceSpy.deleteColumn).not.toHaveBeenCalled();
+    });
+
+    it('should alert and keep the column in the list on error', () => {
+      const col = mockColumn(10);
+      component.columns = [col];
+      boardColumnServiceSpy.deleteColumn.and.returnValue(throwError(() => new Error('fail')));
+      spyOn(window, 'confirm').and.returnValue(true);
+      spyOn(window, 'alert');
+
+      component.deleteColumn(col);
+
+      expect(window.alert).toHaveBeenCalled();
+      expect(component.columns.length).toBe(1);
+    });
+  });
+
+  // ── Task management ──────────────────────────────────────────────────────────
+
+  describe('openAddTask', () => {
+    it('should set addingTaskInColumnId and clear newTaskTitle', () => {
+      component.newTaskTitle = 'leftover';
+      component.openAddTask(10);
+      expect(component.addingTaskInColumnId).toBe(10);
+      expect(component.newTaskTitle).toBe('');
+    });
+  });
+
+  describe('confirmAddTask', () => {
+    it('should close the input without calling the service when title is empty', () => {
+      const col = mockColumn(10);
+      component.newTaskTitle = '   ';
+      component.confirmAddTask(col);
+      expect(taskServiceSpy.createTask).not.toHaveBeenCalled();
+      expect(component.addingTaskInColumnId).toBeNull();
+    });
+
+    it('should call createTask, append the task to the column, and reset state', () => {
+      const col = mockColumn(10);
+      const task = mockTask(1, 10);
+      taskServiceSpy.createTask.and.returnValue(of(task));
+      component.columns = [col];
+      component.newTaskTitle = 'Fix bug';
+
+      component.confirmAddTask(col);
+
+      expect(taskServiceSpy.createTask).toHaveBeenCalledWith({ title: 'Fix bug', columnId: 10 });
+      expect(col.tasks.length).toBe(1);
+      expect(component.addingTaskInColumnId).toBeNull();
+    });
+  });
+
+  describe('cancelAddTask', () => {
+    it('should clear addingTaskInColumnId', () => {
+      component.addingTaskInColumnId = 10;
+      component.cancelAddTask();
+      expect(component.addingTaskInColumnId).toBeNull();
+    });
+  });
+
+  describe('startEditTask', () => {
+    it('should populate editing fields from the task', () => {
+      const task: Task = { ...mockTask(), title: 'Do work', description: 'Details' };
+      component.startEditTask(task);
+      expect(component.editingTask).toEqual(task);
+      expect(component.editingTaskTitle).toBe('Do work');
+      expect(component.editingTaskDescription).toBe('Details');
+    });
+
+    it('should set editingTaskDescription to empty string when description is null', () => {
+      const task = mockTask();
+      component.startEditTask(task);
+      expect(component.editingTaskDescription).toBe('');
+    });
+  });
+
+  describe('confirmEditTask', () => {
+    it('should do nothing when editingTask is null', () => {
+      component.editingTask = null;
+      component.confirmEditTask();
+      expect(taskServiceSpy.updateTask).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when the title is empty', () => {
+      component.editingTask = mockTask();
+      component.editingTaskTitle = '   ';
+      component.confirmEditTask();
+      expect(taskServiceSpy.updateTask).not.toHaveBeenCalled();
+    });
+
+    it('should call updateTask and update the task in its column', () => {
+      const task = mockTask(1, 10);
+      const updated = { ...task, title: 'Fixed' };
+      const col = { ...mockColumn(10), tasks: [task] };
+      component.columns = [col];
+      component.editingTask = task;
+      component.editingTaskTitle = 'Fixed';
+      component.editingTaskDescription = '';
+      taskServiceSpy.updateTask.and.returnValue(of(updated));
+
+      component.confirmEditTask();
+
+      expect(taskServiceSpy.updateTask).toHaveBeenCalledWith(1, { title: 'Fixed', description: undefined });
+      expect(component.columns[0].tasks[0].title).toBe('Fixed');
+      expect(component.editingTask).toBeNull();
+    });
+  });
+
+  describe('cancelEditTask', () => {
+    it('should clear editingTask', () => {
+      component.editingTask = mockTask();
+      component.cancelEditTask();
+      expect(component.editingTask).toBeNull();
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('should call deleteTask and remove the task from the column', () => {
+      const task = mockTask(1, 10);
+      const col = { ...mockColumn(10), tasks: [task, mockTask(2, 10)] };
+      component.columns = [col];
+      taskServiceSpy.deleteTask.and.returnValue(of(undefined));
+      spyOn(window, 'confirm').and.returnValue(true);
+
+      component.deleteTask(task, col);
+
+      expect(taskServiceSpy.deleteTask).toHaveBeenCalledWith(1);
+      expect(col.tasks.length).toBe(1);
+      expect(col.tasks[0].id).toBe(2);
+    });
+
+    it('should not call the service when confirm is cancelled', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      component.deleteTask(mockTask(), mockColumn());
+      expect(taskServiceSpy.deleteTask).not.toHaveBeenCalled();
+    });
+
+    it('should alert and keep the task in the column on error', () => {
+      const task = mockTask(1, 10);
+      const col = { ...mockColumn(10), tasks: [task] };
+      component.columns = [col];
+      taskServiceSpy.deleteTask.and.returnValue(throwError(() => new Error('fail')));
+      spyOn(window, 'confirm').and.returnValue(true);
+      spyOn(window, 'alert');
+
+      component.deleteTask(task, col);
+
+      expect(window.alert).toHaveBeenCalled();
+      expect(col.tasks.length).toBe(1);
+    });
+  });
+});

--- a/apps/frontend/src/app/projects/board-column.service.spec.ts
+++ b/apps/frontend/src/app/projects/board-column.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { BoardColumnService } from '@/app/projects/board-column.service';
+import { BoardColumn, CreateBoardColumnDto, UpdateBoardColumnDto } from '@/app/projects/board-column.model';
+import { environment } from '@/environments/environment';
+
+const API_URL = `${environment.apiUrl}/board-columns`;
+
+const mockColumn = (): BoardColumn => ({
+  id: 1,
+  name: 'To Do',
+  order: 0,
+  projectId: 10,
+  tasks: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('BoardColumnService', () => {
+  let service: BoardColumnService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(BoardColumnService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getColumns', () => {
+    it('should GET columns for a project with projectId as query param', () => {
+      const columns = [mockColumn()];
+      service.getColumns(10).subscribe(result => expect(result).toEqual(columns));
+      const req = httpMock.expectOne(r => r.url === API_URL && r.params.get('projectId') === '10');
+      expect(req.request.method).toBe('GET');
+      req.flush(columns);
+    });
+  });
+
+  describe('createColumn', () => {
+    it('should POST a new column and return it', () => {
+      const dto: CreateBoardColumnDto = { name: 'Backlog', projectId: 10 };
+      const column = mockColumn();
+      service.createColumn(dto).subscribe(result => expect(result).toEqual(column));
+      const req = httpMock.expectOne(API_URL);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(column);
+    });
+  });
+
+  describe('updateColumn', () => {
+    it('should PATCH a column and return the updated entity', () => {
+      const dto: UpdateBoardColumnDto = { name: 'Review' };
+      const updated = { ...mockColumn(), name: 'Review' };
+      service.updateColumn(1, dto).subscribe(result => expect(result).toEqual(updated));
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual(dto);
+      req.flush(updated);
+    });
+  });
+
+  describe('deleteColumn', () => {
+    it('should DELETE the column', () => {
+      service.deleteColumn(1).subscribe(result => expect(result).toBeNull());
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('HTTP errors', () => {
+    it('should propagate HTTP errors without transformation', () => {
+      service.getColumns(10).subscribe({ error: (err) => expect(err.status).toBe(403) });
+      const req = httpMock.expectOne(r => r.url === API_URL && r.params.get('projectId') === '10');
+      req.flush(null, { status: 403, statusText: 'Forbidden' });
+    });
+  });
+});

--- a/apps/frontend/src/app/projects/project-form/project-form.spec.ts
+++ b/apps/frontend/src/app/projects/project-form/project-form.spec.ts
@@ -1,0 +1,166 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ProjectForm } from '@/app/projects/project-form/project-form';
+import { ProjectService } from '@/app/projects/project.service';
+import { Project } from '@/app/projects/project.model';
+
+const mockProject = (): Project => ({
+  id: 1,
+  name: 'Alpha',
+  description: 'Test project',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('ProjectForm', () => {
+  let component: ProjectForm;
+  let fixture: ComponentFixture<ProjectForm>;
+  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
+
+  beforeEach(async () => {
+    projectServiceSpy = jasmine.createSpyObj<ProjectService>('ProjectService', [
+      'createProject',
+      'updateProject',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectForm],
+      providers: [{ provide: ProjectService, useValue: projectServiceSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectForm);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // ── Create mode ──────────────────────────────────────────────────────────────
+
+  describe('create mode (no project input)', () => {
+    it('should start with isEditMode = false', () => {
+      expect(component.isEditMode).toBeFalse();
+    });
+
+    it('should start with an empty form', () => {
+      expect(component.form.value).toEqual({ name: '', description: '' });
+    });
+
+    it('should mark all fields touched and not call service when form is invalid', () => {
+      spyOn(component.form, 'markAllAsTouched');
+      component.onSubmit();
+      expect(component.form.markAllAsTouched).toHaveBeenCalled();
+      expect(projectServiceSpy.createProject).not.toHaveBeenCalled();
+    });
+
+    it('should call createProject and emit saved on success', () => {
+      const created = mockProject();
+      projectServiceSpy.createProject.and.returnValue(of(created));
+      const savedSpy = spyOn(component.saved, 'emit');
+
+      component.form.setValue({ name: 'Alpha', description: 'Desc' });
+      component.onSubmit();
+
+      expect(projectServiceSpy.createProject).toHaveBeenCalledWith({
+        name: 'Alpha',
+        description: 'Desc',
+      });
+      expect(savedSpy).toHaveBeenCalledWith(created);
+      expect(component.submitting).toBeFalse();
+    });
+
+    it('should show errorMessage and reset submitting on error', () => {
+      projectServiceSpy.createProject.and.returnValue(throwError(() => new Error('fail')));
+
+      component.form.setValue({ name: 'Alpha', description: '' });
+      component.onSubmit();
+
+      expect(component.errorMessage).toBe('Failed to create project. Please try again.');
+      expect(component.submitting).toBeFalse();
+    });
+  });
+
+  // ── Edit mode ────────────────────────────────────────────────────────────────
+
+  describe('edit mode (project input provided)', () => {
+    beforeEach(() => {
+      component.project = mockProject();
+      component.ngOnChanges();
+      fixture.detectChanges();
+    });
+
+    it('should set isEditMode = true', () => {
+      expect(component.isEditMode).toBeTrue();
+    });
+
+    it('should pre-fill the form with the project values', () => {
+      expect(component.form.value).toEqual({ name: 'Alpha', description: 'Test project' });
+    });
+
+    it('should call updateProject and emit saved on success', () => {
+      const updated = { ...mockProject(), name: 'Alpha v2' };
+      projectServiceSpy.updateProject.and.returnValue(of(updated));
+      const savedSpy = spyOn(component.saved, 'emit');
+
+      component.form.setValue({ name: 'Alpha v2', description: 'Test project' });
+      component.onSubmit();
+
+      expect(projectServiceSpy.updateProject).toHaveBeenCalledWith(
+        1,
+        { name: 'Alpha v2', description: 'Test project' },
+      );
+      expect(savedSpy).toHaveBeenCalledWith(updated);
+    });
+
+    it('should show errorMessage on update error', () => {
+      projectServiceSpy.updateProject.and.returnValue(throwError(() => new Error('fail')));
+
+      component.form.setValue({ name: 'Alpha v2', description: '' });
+      component.onSubmit();
+
+      expect(component.errorMessage).toBe('Failed to update project. Please try again.');
+    });
+
+    it('should reset form when switching back to create mode', () => {
+      component.project = null;
+      component.ngOnChanges();
+
+      expect(component.isEditMode).toBeFalse();
+      expect(component.form.value).toEqual({ name: null, description: null });
+    });
+  });
+
+  // ── onCancel ─────────────────────────────────────────────────────────────────
+
+  describe('onCancel', () => {
+    it('should emit the cancelled event', () => {
+      const cancelledSpy = spyOn(component.cancelled, 'emit');
+      component.onCancel();
+      expect(cancelledSpy).toHaveBeenCalled();
+    });
+
+    it('should emit cancelled when the Escape key is pressed on the document', () => {
+      const cancelledSpy = spyOn(component.cancelled, 'emit');
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(cancelledSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ── description omitted when empty ───────────────────────────────────────────
+
+  describe('description handling', () => {
+    it('should pass undefined for description when the field is empty', () => {
+      const created = mockProject();
+      projectServiceSpy.createProject.and.returnValue(of(created));
+
+      component.form.setValue({ name: 'Alpha', description: '' });
+      component.onSubmit();
+
+      expect(projectServiceSpy.createProject).toHaveBeenCalledWith(
+        jasmine.objectContaining({ description: undefined }),
+      );
+    });
+  });
+});

--- a/apps/frontend/src/app/projects/project-form/project-form.ts
+++ b/apps/frontend/src/app/projects/project-form/project-form.ts
@@ -69,8 +69,9 @@ export class ProjectForm implements OnChanges {
 
     const { name, description } = this.form.value;
 
+    // || is intentional: '' (cleared field) must be omitted from the DTO, not sent as an empty string
     if (this.project) {
-      const dto: UpdateProjectDto = { name: name!, description: description ?? undefined };
+      const dto: UpdateProjectDto = { name: name!, description: description || undefined };
       this.projectService.updateProject(this.project.id, dto).subscribe({
         next: (updated) => {
           this.submitting = false;
@@ -82,7 +83,7 @@ export class ProjectForm implements OnChanges {
         },
       });
     } else {
-      const dto: CreateProjectDto = { name: name!, description: description ?? undefined };
+      const dto: CreateProjectDto = { name: name!, description: description || undefined };
       this.projectService.createProject(dto).subscribe({
         next: (created) => {
           this.submitting = false;

--- a/apps/frontend/src/app/projects/project.service.spec.ts
+++ b/apps/frontend/src/app/projects/project.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ProjectService } from '@/app/projects/project.service';
+import { Project, CreateProjectDto, UpdateProjectDto } from '@/app/projects/project.model';
+import { environment } from '@/environments/environment';
+
+const API_URL = `${environment.apiUrl}/projects`;
+
+const mockProject = (): Project => ({
+  id: 1,
+  name: 'Alpha',
+  description: 'Test project',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ProjectService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getProjects', () => {
+    it('should GET all projects', () => {
+      const projects = [mockProject()];
+      service.getProjects().subscribe(result => expect(result).toEqual(projects));
+      const req = httpMock.expectOne(API_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush(projects);
+    });
+  });
+
+  describe('getProject', () => {
+    it('should GET a single project by id', () => {
+      const project = mockProject();
+      service.getProject(1).subscribe(result => expect(result).toEqual(project));
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(project);
+    });
+  });
+
+  describe('createProject', () => {
+    it('should POST a new project and return it', () => {
+      const dto: CreateProjectDto = { name: 'Alpha', description: 'Desc' };
+      const project = mockProject();
+      service.createProject(dto).subscribe(result => expect(result).toEqual(project));
+      const req = httpMock.expectOne(API_URL);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(project);
+    });
+  });
+
+  describe('updateProject', () => {
+    it('should PATCH an existing project and return the updated entity', () => {
+      const dto: UpdateProjectDto = { name: 'Alpha v2' };
+      const updated = { ...mockProject(), name: 'Alpha v2' };
+      service.updateProject(1, dto).subscribe(result => expect(result).toEqual(updated));
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual(dto);
+      req.flush(updated);
+    });
+  });
+
+  describe('deleteProject', () => {
+    it('should DELETE the project', () => {
+      service.deleteProject(1).subscribe(result => expect(result).toBeNull());
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('HTTP errors', () => {
+    it('should propagate HTTP errors without transformation', () => {
+      service.getProjects().subscribe({ error: (err) => expect(err.status).toBe(403) });
+      httpMock.expectOne(API_URL).flush(null, { status: 403, statusText: 'Forbidden' });
+    });
+  });
+});

--- a/apps/frontend/src/app/projects/task.service.spec.ts
+++ b/apps/frontend/src/app/projects/task.service.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TaskService } from '@/app/projects/task.service';
+import { Task, CreateTaskDto, UpdateTaskDto } from '@/app/projects/task.model';
+import { environment } from '@/environments/environment';
+
+const API_URL = `${environment.apiUrl}/tasks`;
+
+const mockTask = (): Task => ({
+  id: 1,
+  title: 'Fix bug',
+  description: null,
+  order: 0,
+  columnId: 20,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('TaskService', () => {
+  let service: TaskService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(TaskService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createTask', () => {
+    it('should POST a new task and return it', () => {
+      const dto: CreateTaskDto = { title: 'Fix bug', columnId: 20 };
+      const task = mockTask();
+      service.createTask(dto).subscribe(result => expect(result).toEqual(task));
+      const req = httpMock.expectOne(API_URL);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+      req.flush(task);
+    });
+  });
+
+  describe('updateTask', () => {
+    it('should PATCH a task and return the updated entity', () => {
+      const dto: UpdateTaskDto = { title: 'Updated', columnId: 21, order: 1 };
+      const updated = { ...mockTask(), title: 'Updated', columnId: 21, order: 1 };
+      service.updateTask(1, dto).subscribe(result => expect(result).toEqual(updated));
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual(dto);
+      req.flush(updated);
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('should DELETE the task', () => {
+      service.deleteTask(1).subscribe(result => expect(result).toBeNull());
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('HTTP errors', () => {
+    it('should propagate HTTP errors without transformation', () => {
+      service.createTask({ title: 'x', columnId: 1 }).subscribe({ error: (err) => expect(err.status).toBe(403) });
+      httpMock.expectOne(API_URL).flush(null, { status: 403, statusText: 'Forbidden' });
+    });
+  });
+});

--- a/apps/frontend/src/app/shared/nav/nav.spec.ts
+++ b/apps/frontend/src/app/shared/nav/nav.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Nav } from '@/app/shared/nav/nav';
+import { Auth } from '@/app/auth/services/auth';
+
+describe('Nav', () => {
+  let component: Nav;
+  let fixture: ComponentFixture<Nav>;
+  let authServiceSpy: jasmine.SpyObj<Auth>;
+  let router: Router;
+
+  beforeEach(async () => {
+    authServiceSpy = jasmine.createSpyObj<Auth>('Auth', ['getUserEmail', 'logout']);
+    authServiceSpy.getUserEmail.and.returnValue('user@test.com');
+
+    await TestBed.configureTestingModule({
+      imports: [Nav],
+      providers: [
+        provideRouter([]),
+        { provide: Auth, useValue: authServiceSpy },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(Nav);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // ── userInitial ─────────────────────────────────────────────────────────────
+
+  describe('userInitial', () => {
+    it('should be the uppercase first character of the user email', () => {
+      expect(component.userInitial).toBe('U');
+    });
+
+    it('should be "?" when getUserEmail returns null', () => {
+      // Change spy before creating a new component instance
+      authServiceSpy.getUserEmail.and.returnValue(null);
+      const noEmailComponent = TestBed.createComponent(Nav).componentInstance;
+      expect(noEmailComponent.userInitial).toBe('?');
+    });
+  });
+
+  // ── toggleMenu ──────────────────────────────────────────────────────────────
+
+  describe('toggleMenu', () => {
+    it('should open the menu when it is closed', () => {
+      component.menuOpen = false;
+      component.toggleMenu();
+      expect(component.menuOpen).toBeTrue();
+    });
+
+    it('should close the menu when it is open', () => {
+      component.menuOpen = true;
+      component.toggleMenu();
+      expect(component.menuOpen).toBeFalse();
+    });
+  });
+
+  // ── logout ──────────────────────────────────────────────────────────────────
+
+  describe('logout', () => {
+    it('should call authService.logout and navigate to /auth/login', () => {
+      spyOn(router, 'navigate');
+      component.logout();
+      expect(authServiceSpy.logout).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+    });
+  });
+
+  // ── onDocumentClick ─────────────────────────────────────────────────────────
+
+  describe('onDocumentClick', () => {
+    it('should close the menu when clicking outside the nav element', () => {
+      component.menuOpen = true;
+      const outsideElement = document.createElement('div');
+      document.body.appendChild(outsideElement);
+
+      component.onDocumentClick({ target: outsideElement } as unknown as MouseEvent);
+
+      expect(component.menuOpen).toBeFalse();
+      document.body.removeChild(outsideElement);
+    });
+
+    it('should keep the menu open when clicking inside the nav element', () => {
+      component.menuOpen = true;
+      component.onDocumentClick({ target: fixture.nativeElement } as unknown as MouseEvent);
+      expect(component.menuOpen).toBeTrue();
+    });
+
+    it('should not change state when the menu is already closed', () => {
+      component.menuOpen = false;
+      const outsideElement = document.createElement('div');
+      document.body.appendChild(outsideElement);
+
+      component.onDocumentClick({ target: outsideElement } as unknown as MouseEvent);
+
+      expect(component.menuOpen).toBeFalse();
+      document.body.removeChild(outsideElement);
+    });
+  });
+});

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -14,9 +14,9 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "preserve",
-    "baseUrl": "./",
+    "rootDir": "../../",
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@shared/validation/*": ["../../libs/shared-validation/src/*"],
       "@shared/dtos/*": ["../../libs/shared-dtos/src/*"]
     }


### PR DESCRIPTION
## Summary

Adds a comprehensive unit test suite across the entire stack — 102 backend Jest tests and 126 frontend Karma/Jasmine tests — achieving full coverage of every service, controller, component, guard, and interceptor. Also fixes two TypeScript configuration issues (`baseUrl` deprecation and missing `rootDir`) that were surfacing as editor errors.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] Chore (deps, tooling, CI)
- [x] Tests

## Related Issue

Closes #<!-- issue number -->

## Changes

**Backend (102 Jest tests)**
- `projects.service.spec.ts` — CRUD, default column creation in transaction, ownership, NotFoundException
- `projects.controller.spec.ts` — delegation and error propagation
- `board-columns.service.spec.ts` — CRUD, auto-order assignment, `projectId` strip on update, access verification
- `board-columns.controller.spec.ts` — delegation
- `tasks.service.spec.ts` — CRUD, pessimistic-lock pattern, cross-column move with auto-order, ForbiddenException
- `tasks.controller.spec.ts` — delegation

**Frontend (126 Karma + Jasmine tests)**
- New: `kanban.spec.ts`, `project-form.spec.ts`, `board-column.service.spec.ts`, `project.service.spec.ts`, `task.service.spec.ts`, `nav.spec.ts`
- Expanded: `auth.spec.ts` (logout, isAuthenticated, getToken, getUserEmail JWT decode), `auth-guard.spec.ts`, `token-interceptor.spec.ts`, `dashboard.spec.ts`, `login.spec.ts`, `register.spec.ts`

**Bug fixes (surfaced by tests)**
- `project-form.ts`: `description ?? undefined` → `description || undefined` so an empty string field is omitted from the DTO rather than sent as `""`

**TypeScript config**
- `apps/backend/tsconfig.json`: removed deprecated `baseUrl`, added explicit `rootDir: "../../"`, dropped `../../libs/**/*` from `include`
- `apps/frontend/tsconfig.json`: same `baseUrl` and `rootDir` fix

**Docs**
- `README.md`: added `🧪 Running Tests` section
- `CHANGELOG.md`: populated `[Unreleased]` with tests added and tsconfig fixes

## Testing

- [x] `npm run lint` passes with no errors
- [x] Backend unit tests pass — 102/102 (`cd apps/backend && npm test`)
- [x] Frontend unit tests pass — 126/126 (`cd apps/frontend && ng test --watch=false --browsers=ChromeHeadless`)
- [x] Added or updated tests for new logic

## Screenshots

N/A — no UI changes.

## Notes for Reviewer

- **Kanban spec** uses `overrideComponent(Kanban, { set: { imports: [NavStub] } })` to replace the Nav child component; this avoids pulling in the Auth + Router dependency tree from the real Nav and keeps the test isolated to Kanban's own logic.
- **Tasks service spec** mocks `columnsRepository.manager.transaction` (not `tasksRepository`) because `TasksService.create()` opens the transaction on the column repository's manager — the mock must be on the right object or the spy is never called.
- **Login and Register specs** required `provideRouter([])` because both components use `RouterLink`, which needs Angular's router infrastructure even in unit tests.
- The `rootDir: "../../"` change in both tsconfigs is safe: the backend uses webpack (`"builder": "webpack"` in `nest-cli.json`) and the frontend uses esbuild — neither respects tsconfig `outDir` for actual build output, so the change only affects the TypeScript language server.

Closes #23 